### PR TITLE
Fjern støtte for HEIC

### DIFF
--- a/src/components/filopplaster/drag-and-drop/drag-and-drop.tsx
+++ b/src/components/filopplaster/drag-and-drop/drag-and-drop.tsx
@@ -108,7 +108,7 @@ const DragAndDrop = () => {
                 render={() => (
                     <>
                         <div className="filopplasteren" {...getRootProps()}>
-                            <input {...getInputProps()} id="ddfil" />
+                            <input {...getInputProps()} accept={tillatteFiltyper} id="ddfil" />
                             <input
                                 type="hidden"
                                 id="fil_input"
@@ -121,7 +121,7 @@ const DragAndDrop = () => {
                                             }
                                         },
                                         fil_type: () => {
-                                            if (valgtFil && !tillatteFiltyper.includes(valgtFil.type)) {
+                                            if (valgtFil && !tillatteFiltyper.split(',').includes(valgtFil.type)) {
                                                 settInputHarFeil()
                                                 return getLedetekst(tekst('drag_and_drop.filtype'), {
                                                     '%FILNAVN%': valgtFil.name,

--- a/src/utils/fil-utils.ts
+++ b/src/utils/fil-utils.ts
@@ -16,12 +16,12 @@ export const filstørrelseTilBytes = (filstørrelse: string): number => {
     return verdi * k ** i
 }
 
-export const formattertFiltyper = 'png, jpg og mobile bildeformater'
+export const formattertFiltyper = '.png og .jpeg'
 
-export const tillatteFiltyper = 'image/png,image/jpeg,image/heic'.split(',')
+export const tillatteFiltyper = 'image/png,image/jpeg'
 
 export const maxFilstørrelse = filstørrelseTilBytes('5MB')
 
 export const customTruncet = (text: string, size: number) => {
-    return text.length <= size ? text : text.substr(0, size) + '...' + text.substr(-3)
+    return text.length <= size ? text : text.slice(0, size) + '...' + text.slice(-3)
 }


### PR DESCRIPTION
I teorien skal HEIC konverteres til JPEG når det lastes opp fra iPhone og HEIC ikke er støttet.