### PR TITLE
Kall defaultErrorHandler i custom errorHandler

### DIFF
--- a/src/components/sporsmal/sporsmal-form/sporsmal-form.tsx
+++ b/src/components/sporsmal/sporsmal-form/sporsmal-form.tsx
@@ -108,12 +108,13 @@ const SporsmalForm = () => {
                     body: JSON.stringify(sporsmalToRS(sporsmal)),
                     headers: { 'Content-Type': 'application/json' },
                 },
-                (response) => {
+                (response, requestId, defaultErrorHandler) => {
                     if (response.status === 400) {
                         fikk400 = true
                         setFeilState(true)
                     }
                     restFeilet = true
+                    defaultErrorHandler()
                 },
             )
         } catch (e: any) {

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -84,6 +84,17 @@ export const fetchJsonMedRequestId = async (url: string, options: RequestInit = 
     // Kloner reponse sånn at den kan konsumeres flere ganger siden kall til .json() og .text() konsumerer data.
     const clonedResponse = response.clone()
 
+    // Guard for å sjekke at response er OK før vi prøver å parse JSON. defaultErrorHandler i fetchMedRequestId()
+    // forhindrer normalt at det skal kunne skje ved å kaste en exception, men den funksjonaliteten kan ikke garanteres hvis
+    // custom error handlers er brukt.
+    if (!response.ok) {
+        throw new Error(
+            `Response er ${response.status}, så vi parser ikke JSON for til url: ${
+                options.method || 'GET'
+            } ${url} og x_request_id: ${fetchResult.requestId}.`,
+        )
+    }
+
     try {
         return await response.json()
     } catch (e) {


### PR DESCRIPTION
Kaller defaultErrorHandler sånn at vi kaster en exception i stedet for at HTML som kommer fra en feilmelding skal bli forsøkt parset som JSON.