### PR TITLE
Oppgraderer Distroless til nodejs20-debian12@sha256:2818fb8c

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/nodejs20-debian12@sha256:a69b487c1d156e3aeaab0ffb587f46248c8e891e289081a3c28f7104a69c4515
+FROM gcr.io/distroless/nodejs20-debian12@sha256:2818fb8cdc25894d9c6b6e6bf72b4033d949f5d6d65173a6d7aeec0266f03037
 
 ENV NODE_ENV=production
 


### PR DESCRIPTION
Fra flex-cli