### PR TITLE
Tidssone-sikker dato-parsing med date-fns/tz

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
             "name": "sykepengesoknad-frontend",
             "version": "1.0.0",
             "dependencies": {
+                "@date-fns/tz": "^1.5.0",
                 "@grafana/faro-web-sdk": "^1.19.0",
                 "@navikt/aksel-icons": "^7.40.0",
                 "@navikt/ds-css": "^7.40.0",
@@ -25,6 +26,7 @@
                 "@unleash/nextjs": "^1.6.4",
                 "classnames": "^2.5.1",
                 "cookie": "^1.1.1",
+                "date-fns": "^4.3.0",
                 "dayjs": "^1.11.20",
                 "html-react-parser": "^5.2.17",
                 "jose": "^6.2.2",
@@ -543,9 +545,9 @@
             }
         },
         "node_modules/@date-fns/tz": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.2.0.tgz",
-            "integrity": "sha512-LBrd7MiJZ9McsOgxqWX7AaxrDjcFVjWH/tIKJd7pnR7McaslGYOP1QmmiBXdJH/H/yLCT+rcQ7FaPBUxRGUtrg==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.5.0.tgz",
+            "integrity": "sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==",
             "license": "MIT"
         },
         "node_modules/@emnapi/core": {
@@ -5357,9 +5359,9 @@
             }
         },
         "node_modules/date-fns": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-            "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.3.0.tgz",
+            "integrity": "sha512-OYcL+3N/jyWbYdFGqoMAhytDgxP9pbYPUUiRCOgn4Fewaadk9l/Wam4Avciiyp2BgkpfQyBV9B+ehnVJych+eQ==",
             "license": "MIT",
             "funding": {
                 "type": "github",
@@ -10275,6 +10277,22 @@
             },
             "peerDependencies": {
                 "react": ">=16.8.0"
+            }
+        },
+        "node_modules/react-day-picker/node_modules/@date-fns/tz": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.2.0.tgz",
+            "integrity": "sha512-LBrd7MiJZ9McsOgxqWX7AaxrDjcFVjWH/tIKJd7pnR7McaslGYOP1QmmiBXdJH/H/yLCT+rcQ7FaPBUxRGUtrg==",
+            "license": "MIT"
+        },
+        "node_modules/react-day-picker/node_modules/date-fns": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+            "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/kossnocorp"
             }
         },
         "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
         "node": "24"
     },
     "dependencies": {
+        "@date-fns/tz": "^1.5.0",
         "@grafana/faro-web-sdk": "^1.19.0",
         "@navikt/aksel-icons": "^7.40.0",
         "@navikt/ds-css": "^7.40.0",
@@ -22,6 +23,7 @@
         "@unleash/nextjs": "^1.6.4",
         "classnames": "^2.5.1",
         "cookie": "^1.1.1",
+        "date-fns": "^4.3.0",
         "dayjs": "^1.11.20",
         "html-react-parser": "^5.2.17",
         "jose": "^6.2.2",

--- a/playwright/tidssone-datovisning.spec.ts
+++ b/playwright/tidssone-datovisning.spec.ts
@@ -1,0 +1,123 @@
+import { test, expect } from '@playwright/test'
+
+import { arbeidstaker } from '../src/data/mock/data/soknad/arbeidstaker'
+import { arbeidsledigKvittering } from '../src/data/mock/data/soknad/soknader-integration'
+
+import { checkViStolerPaDeg, harSoknaderlisteHeading, trykkPaSoknadMedId } from './utils/utilities'
+
+/**
+ * Tidssone-tester som verifiserer at datoer håndteres korrekt i vest-tidssoner.
+ *
+ * Kjerneproblemet: `new Date('2020-01-01')` = UTC midnight.
+ * I UTC-5 (New York): getDate() = 31 (desember 2019), getFullYear() = 2019.
+ *
+ * Buggen: DatePicker brukte `new Date(sporsmal.min)` for fromDate.
+ * Med min='2020-01-01' i NYC ble fromDate = 2019-12-31 → desember navigerbar.
+ * Fix: Bruker TZDate med eksplisitt Europe/Oslo tidssone.
+ */
+
+const arbeidstakerId = arbeidstaker.id
+const arbeidsledigId = arbeidsledigKvittering.id
+
+test.describe('Tidssone: periodevisning', () => {
+    test.describe('New York (UTC-5)', () => {
+        test.use({ timezoneId: 'America/New_York' })
+
+        test('Periodevisning i søknadslisten er korrekt', async ({ page }) => {
+            await page.goto('/syk/sykepengesoknad')
+            await harSoknaderlisteHeading(page)
+
+            const soknadLink = page.locator(`[data-cy="link-listevisning-${arbeidstakerId}"]`)
+            await expect(soknadLink).toContainText('1. april – 24. mai 2020')
+        })
+
+        test('Manuell dato-input viser riktig periode', async ({ page }) => {
+            test.setTimeout(60000)
+            await page.goto('/syk/sykepengesoknad')
+            await harSoknaderlisteHeading(page)
+            await trykkPaSoknadMedId(page, arbeidstakerId)
+
+            await checkViStolerPaDeg(page)
+
+            await page.locator('[data-cy="ja-nei-stor"] input[value="JA"]').click()
+            await expect(page.getByText('Når begynte du å jobbe igjen?')).toBeVisible()
+
+            const datoInput = page.locator('.navds-date__field-input')
+            await datoInput.fill('01.04.2020')
+            await datoInput.blur()
+
+            await expect(page.getByText('1. – 24. april 2020', { exact: false })).toBeVisible()
+        })
+    })
+
+    test.describe('Oslo (kontroll)', () => {
+        test.use({ timezoneId: 'Europe/Oslo' })
+
+        test('Periodevisning i søknadslisten er korrekt', async ({ page }) => {
+            await page.goto('/syk/sykepengesoknad')
+            await harSoknaderlisteHeading(page)
+
+            const soknadLink = page.locator(`[data-cy="link-listevisning-${arbeidstakerId}"]`)
+            await expect(soknadLink).toContainText('1. april – 24. mai 2020')
+        })
+    })
+})
+
+test.describe('Tidssone: DatePicker fromDate-grense', () => {
+    /**
+     * Verifiserer at DatePicker korrekt begrenser navigering til måneder
+     * utenfor min/max-intervallet, uavhengig av brukerens tidssone.
+     *
+     * Mock: arbeidsledigKvittering → FRISKMELDT_START (min='2020-01-01', max='2020-01-10')
+     */
+    test.describe('New York (UTC-5)', () => {
+        test.use({ timezoneId: 'America/New_York' })
+
+        test('DatePicker blokkerer navigering forbi januar 2020', async ({ page }) => {
+            test.setTimeout(60000)
+
+            await page.goto(
+                `/syk/sykepengesoknad/soknader/${arbeidsledigId}/1?testperson=integrasjon-soknader`,
+            )
+
+            await checkViStolerPaDeg(page)
+
+            await page.getByRole('radio', { name: 'Nei' }).click()
+            await expect(page.getByText('Fra hvilken dato trengte du ikke lenger sykmeldingen?')).toBeVisible()
+
+            const openButton = page.getByRole('button', { name: 'Åpne datovelger' })
+            await openButton.click()
+
+            await expect(page.getByRole('grid')).toBeVisible()
+
+            // fromDate skal være 1. januar 2020 → forrige-knapp skal være deaktivert
+            const prevButton = page.getByRole('button', { name: /Forrige måned|Go to previous month/i })
+            await expect(prevButton).toBeDisabled()
+        })
+    })
+
+    test.describe('Oslo (kontroll)', () => {
+        test.use({ timezoneId: 'Europe/Oslo' })
+
+        test('DatePicker blokkerer navigering forbi januar 2020', async ({ page }) => {
+            test.setTimeout(60000)
+
+            await page.goto(
+                `/syk/sykepengesoknad/soknader/${arbeidsledigId}/1?testperson=integrasjon-soknader`,
+            )
+
+            await checkViStolerPaDeg(page)
+
+            await page.getByRole('radio', { name: 'Nei' }).click()
+            await expect(page.getByText('Fra hvilken dato trengte du ikke lenger sykmeldingen?')).toBeVisible()
+
+            const openButton = page.getByRole('button', { name: 'Åpne datovelger' })
+            await openButton.click()
+
+            await expect(page.getByRole('grid')).toBeVisible()
+
+            const prevButton = page.getByRole('button', { name: /Forrige måned|Go to previous month/i })
+            await expect(prevButton).toBeDisabled()
+        })
+    })
+})

--- a/playwright/tidssone-datovisning.spec.ts
+++ b/playwright/tidssone-datovisning.spec.ts
@@ -1,8 +1,7 @@
-import { test, expect } from './utils/fixtures'
-
 import { arbeidstaker } from '../src/data/mock/data/soknad/arbeidstaker'
 import { arbeidsledigKvittering } from '../src/data/mock/data/soknad/soknader-integration'
 
+import { test, expect } from './utils/fixtures'
 import { checkViStolerPaDeg, harSoknaderlisteHeading, trykkPaSoknadMedId } from './utils/utilities'
 
 /**

--- a/playwright/tidssone-datovisning.spec.ts
+++ b/playwright/tidssone-datovisning.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from './utils/fixtures'
 
 import { arbeidstaker } from '../src/data/mock/data/soknad/arbeidstaker'
 import { arbeidsledigKvittering } from '../src/data/mock/data/soknad/soknader-integration'

--- a/playwright/tidssone-datovisning.spec.ts
+++ b/playwright/tidssone-datovisning.spec.ts
@@ -76,9 +76,7 @@ test.describe('Tidssone: DatePicker fromDate-grense', () => {
         test('DatePicker blokkerer navigering forbi januar 2020', async ({ page }) => {
             test.setTimeout(60000)
 
-            await page.goto(
-                `/syk/sykepengesoknad/soknader/${arbeidsledigId}/1?testperson=integrasjon-soknader`,
-            )
+            await page.goto(`/syk/sykepengesoknad/soknader/${arbeidsledigId}/1?testperson=integrasjon-soknader`)
 
             await checkViStolerPaDeg(page)
 
@@ -102,9 +100,7 @@ test.describe('Tidssone: DatePicker fromDate-grense', () => {
         test('DatePicker blokkerer navigering forbi januar 2020', async ({ page }) => {
             test.setTimeout(60000)
 
-            await page.goto(
-                `/syk/sykepengesoknad/soknader/${arbeidsledigId}/1?testperson=integrasjon-soknader`,
-            )
+            await page.goto(`/syk/sykepengesoknad/soknader/${arbeidsledigId}/1?testperson=integrasjon-soknader`)
 
             await checkViStolerPaDeg(page)
 

--- a/playwright/utils/fixtures.ts
+++ b/playwright/utils/fixtures.ts
@@ -19,7 +19,9 @@ test.beforeEach(async ({ context, page }) => {
     await context.clearCookies()
 
     // Skjul dev-tools hint så de ikke er i veien for visuelle tester.
-    await page.addInitScript(() => {
+    // Bruker context.addInitScript slik at scriptet kjøres på alle sider i konteksten,
+    // ikke bare den første — nødvendig når test.use({ timezoneId }) oppretter ny kontekst.
+    await context.addInitScript(() => {
         window.localStorage.setItem('devtools-hint', 'false')
     })
     await fjernAnimasjoner(page)

--- a/src/components/listevisning/fremtidige-soknader-teaser.tsx
+++ b/src/components/listevisning/fremtidige-soknader-teaser.tsx
@@ -1,5 +1,5 @@
 import { BodyLong, Modal, ReadMore } from '@navikt/ds-react'
-import dayjs from 'dayjs'
+import { addDays } from 'date-fns'
 import React, { useState } from 'react'
 import { ClockDashedIcon } from '@navikt/aksel-icons'
 
@@ -34,7 +34,7 @@ const FremtidigeSoknaderTeaser = ({ soknad }: SykepengesoknadTeaserProps) => {
             >
                 <Modal.Body>
                     <BodyLong spacing>
-                        {`Du må vente med å søke om sykepenger til perioden er over ${tilLesbarDatoMedArstall(dayjs(soknad.tom).add(1, 'day'))}. Vi sender deg en melding når søknaden er klar til å fylles ut.`}
+                        {`Du må vente med å søke om sykepenger til perioden er over ${tilLesbarDatoMedArstall(addDays(soknad.tom!, 1))}. Vi sender deg en melding når søknaden er klar til å fylles ut.`}
                     </BodyLong>
 
                     <ReadMore header="Hvorfor kan jeg ikke søke nå?">

--- a/src/components/listevisning/listevisning-lenkepanel.tsx
+++ b/src/components/listevisning/listevisning-lenkepanel.tsx
@@ -1,6 +1,6 @@
 import { Button, LinkPanel, Tag, BodyShort } from '@navikt/ds-react'
+import { addDays } from 'date-fns'
 import React from 'react'
-import dayjs from 'dayjs'
 import Link from 'next/link'
 
 import { cn } from '../../utils/tw-utils'
@@ -103,7 +103,7 @@ const hentTeaserStatustekst = (soknad: RSSoknadmetadata) => {
     }
     if (soknad.status === RSSoknadstatus.FREMTIDIG) {
         return getLedetekst(tekst(`soknad.teaser.status.${soknad.status}` as any), {
-            '%DATO%': tilLesbarDatoMedArstall(dayjs(soknad.tom).add(1, 'day')),
+            '%DATO%': tilLesbarDatoMedArstall(addDays(soknad.tom!, 1)),
         })
     }
     if (soknad.status === RSSoknadstatus.SENDT) {

--- a/src/components/sporsmal/hent-svar.ts
+++ b/src/components/sporsmal/hent-svar.ts
@@ -1,9 +1,8 @@
-import dayjs from 'dayjs'
-
 import { SvarEnums } from '../../types/enums'
 import { RSSvar } from '../../types/rs-types/rs-svar'
 import { RSSvartype } from '../../types/rs-types/rs-svartype'
 import { Sporsmal, svarverdiToKvittering } from '../../types/types'
+import { toDate } from '../../utils/dato-utils'
 
 import { FormPeriode } from './typer/periode-komp'
 
@@ -16,7 +15,7 @@ export const hentSvar = (sporsmal: Sporsmal): any => {
             return sporsmal.undersporsmal
                 .map((uspm) => uspm.svarliste.svar[0]?.verdi)
                 .filter((v) => v !== undefined && v !== 'Ikke til behandling')
-                .map((s) => dayjs(s).toDate())
+                .map((s) => toDate(s))
 
         case RSSvartype.CHECKBOX_PANEL:
         case RSSvartype.CHECKBOX:
@@ -37,10 +36,10 @@ export const hentSvar = (sporsmal: Sporsmal): any => {
 
         case RSSvartype.DATO:
         case RSSvartype.AAR_MAANED:
-            return svar?.verdi ? dayjs(svar.verdi).toDate() : undefined
+            return svar?.verdi ? toDate(svar.verdi) : undefined
 
         case RSSvartype.DATOER:
-            return svarliste.svar.map((i) => new Date(i.verdi))
+            return svarliste.svar.map((i) => toDate(i.verdi))
 
         case RSSvartype.LAND:
         case RSSvartype.COMBOBOX_MULTI:

--- a/src/components/sporsmal/sporsmal-utils.ts
+++ b/src/components/sporsmal/sporsmal-utils.ts
@@ -1,10 +1,12 @@
 import { FieldError, FieldErrorsImpl, Merge } from 'react-hook-form'
-import dayjs from 'dayjs'
+import { isBefore, isAfter, differenceInYears } from 'date-fns'
+import { TZDate } from '@date-fns/tz'
 
 import { RSSvartype } from '../../types/rs-types/rs-svartype'
 import { Soknad, Sporsmal } from '../../types/types'
 import { SEPARATOR } from '../../utils/constants'
 import { tekst } from '../../utils/tekster'
+import { toDate } from '../../utils/dato-utils'
 
 export const erSisteSide = (soknad: Soknad, sidenummer: number) => {
     const sporsmal = soknad.sporsmal[sidenummer - 1]
@@ -128,20 +130,20 @@ export const hentGeneriskFeilmelding = (
 }
 
 export const maanedKalenderApnesPa = (sporsmalMin: string | null, sporsmalMax: string | null) => {
-    const iDag = dayjs()
-    const min = sporsmalMin ? dayjs(sporsmalMin) : dayjs('1900')
-    const max = sporsmalMax ? dayjs(sporsmalMax) : dayjs('2100')
+    const iDag = new TZDate(new Date(), 'Europe/Oslo')
+    const min = sporsmalMin ? toDate(sporsmalMin) : toDate('1900-01-01')
+    const max = sporsmalMax ? toDate(sporsmalMax) : toDate('2100-01-01')
 
-    if (min.isBefore(iDag) && max.isAfter(iDag)) {
-        return iDag.toDate()
+    if (isBefore(min, iDag) && isAfter(max, iDag)) {
+        return iDag
     }
 
-    return max.toDate()
+    return max
 }
 
 export const kalenderMedDropdownCaption = (sporsmalMin: string | null, sporsmalMax: string | null) => {
     if (!sporsmalMin || !sporsmalMax) {
         return false
     }
-    return dayjs(sporsmalMax).diff(dayjs(sporsmalMin), 'years') >= 1
+    return differenceInYears(toDate(sporsmalMax), toDate(sporsmalMin)) >= 1
 }

--- a/src/components/sporsmal/sporsmal-utils.ts
+++ b/src/components/sporsmal/sporsmal-utils.ts
@@ -1,12 +1,11 @@
 import { FieldError, FieldErrorsImpl, Merge } from 'react-hook-form'
 import { isBefore, isAfter, differenceInYears } from 'date-fns'
-import { TZDate } from '@date-fns/tz'
 
 import { RSSvartype } from '../../types/rs-types/rs-svartype'
 import { Soknad, Sporsmal } from '../../types/types'
 import { SEPARATOR } from '../../utils/constants'
 import { tekst } from '../../utils/tekster'
-import { toDate } from '../../utils/dato-utils'
+import { now, toDate } from '../../utils/dato-utils'
 
 export const erSisteSide = (soknad: Soknad, sidenummer: number) => {
     const sporsmal = soknad.sporsmal[sidenummer - 1]
@@ -130,7 +129,7 @@ export const hentGeneriskFeilmelding = (
 }
 
 export const maanedKalenderApnesPa = (sporsmalMin: string | null, sporsmalMax: string | null) => {
-    const iDag = new TZDate(new Date(), 'Europe/Oslo')
+    const iDag = now()
     const min = sporsmalMin ? toDate(sporsmalMin) : toDate('1900-01-01')
     const max = sporsmalMax ? toDate(sporsmalMax) : toDate('2100-01-01')
 

--- a/src/components/sporsmal/typer/aar-maaned-komp.tsx
+++ b/src/components/sporsmal/typer/aar-maaned-komp.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import { useController } from 'react-hook-form'
 import { BodyShort, MonthPicker, MonthValidationT, useMonthpicker } from '@navikt/ds-react'
 
+import { toDate } from '../../../utils/dato-utils'
 import { SpmProps } from '../sporsmal-form/sporsmal-form'
 import { kalenderMedDropdownCaption } from '../sporsmal-utils'
 import { validerMaaned } from '../../../utils/sporsmal/valider-dato'
@@ -18,9 +19,9 @@ function AarMaanedInput(props: SpmProps) {
     })
 
     const { monthpickerProps, inputProps } = useMonthpicker({
-        fromDate: sporsmal.min ? new Date(sporsmal.min) : new Date('1900'),
-        toDate: sporsmal.max ? new Date(sporsmal.max) : new Date('2100'),
-        defaultYear: sporsmal.max ? new Date(sporsmal.max) : new Date('2100'),
+        fromDate: sporsmal.min ? toDate(sporsmal.min) : new Date('1900'),
+        toDate: sporsmal.max ? toDate(sporsmal.max) : new Date('2100'),
+        defaultYear: sporsmal.max ? toDate(sporsmal.max) : new Date('2100'),
         allowTwoDigitYear: false,
         locale: 'nb',
         onMonthChange: field.onChange,

--- a/src/components/sporsmal/typer/aar-maaned-komp.tsx
+++ b/src/components/sporsmal/typer/aar-maaned-komp.tsx
@@ -19,9 +19,9 @@ function AarMaanedInput(props: SpmProps) {
     })
 
     const { monthpickerProps, inputProps } = useMonthpicker({
-        fromDate: sporsmal.min ? toDate(sporsmal.min) : new Date('1900'),
-        toDate: sporsmal.max ? toDate(sporsmal.max) : new Date('2100'),
-        defaultYear: sporsmal.max ? toDate(sporsmal.max) : new Date('2100'),
+        fromDate: sporsmal.min ? toDate(sporsmal.min) : toDate('1900-01-01'),
+        toDate: sporsmal.max ? toDate(sporsmal.max) : toDate('2100-01-01'),
+        defaultYear: sporsmal.max ? toDate(sporsmal.max) : toDate('2100-01-01'),
         allowTwoDigitYear: false,
         locale: 'nb',
         onMonthChange: field.onChange,

--- a/src/components/sporsmal/typer/dato-komp.tsx
+++ b/src/components/sporsmal/typer/dato-komp.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import { useController } from 'react-hook-form'
 import { BodyShort, DatePicker, DateValidationT, useDatepicker } from '@navikt/ds-react'
 
+import { toDate } from '../../../utils/dato-utils'
 import { SpmProps } from '../sporsmal-form/sporsmal-form'
 import UndersporsmalListe from '../undersporsmal/undersporsmal-liste'
 import validerDato from '../../../utils/sporsmal/valider-dato'
@@ -20,8 +21,8 @@ function DatoInput(props: SpmProps) {
     })
 
     const { datepickerProps, inputProps } = useDatepicker({
-        fromDate: sporsmal.min ? new Date(sporsmal.min) : new Date('1900'),
-        toDate: sporsmal.max ? new Date(sporsmal.max) : new Date('2100'),
+        fromDate: sporsmal.min ? toDate(sporsmal.min) : new Date('1900'),
+        toDate: sporsmal.max ? toDate(sporsmal.max) : new Date('2100'),
         defaultMonth: maanedKalenderApnesPa(sporsmal.min, sporsmal.max),
         allowTwoDigitYear: false,
         defaultSelected: field.value,

--- a/src/components/sporsmal/typer/dato-komp.tsx
+++ b/src/components/sporsmal/typer/dato-komp.tsx
@@ -21,8 +21,8 @@ function DatoInput(props: SpmProps) {
     })
 
     const { datepickerProps, inputProps } = useDatepicker({
-        fromDate: sporsmal.min ? toDate(sporsmal.min) : new Date('1900'),
-        toDate: sporsmal.max ? toDate(sporsmal.max) : new Date('2100'),
+        fromDate: sporsmal.min ? toDate(sporsmal.min) : toDate('1900-01-01'),
+        toDate: sporsmal.max ? toDate(sporsmal.max) : toDate('2100-01-01'),
         defaultMonth: maanedKalenderApnesPa(sporsmal.min, sporsmal.max),
         allowTwoDigitYear: false,
         defaultSelected: field.value,

--- a/src/components/sporsmal/typer/periode-komp.tsx
+++ b/src/components/sporsmal/typer/periode-komp.tsx
@@ -1,9 +1,10 @@
 import { Button, DatePicker, RangeValidationT, useRangeDatepicker } from '@navikt/ds-react'
-import dayjs from 'dayjs'
+import { format } from 'date-fns'
 import React, { useState } from 'react'
 import { useController, useFormContext } from 'react-hook-form'
 import { TrashIcon } from '@navikt/aksel-icons'
 
+import { toDate } from '../../../utils/dato-utils'
 import { validerFom, validerPeriode, validerTom } from '../../../utils/sporsmal/valider-periode'
 import { SpmProps } from '../sporsmal-form/sporsmal-form'
 import { kalenderMedDropdownCaption, maanedKalenderApnesPa } from '../sporsmal-utils'
@@ -39,19 +40,19 @@ const PeriodeKomp = ({ sporsmal, index, slettPeriode, antallPerioder }: AllProps
     })
 
     const { datepickerProps, toInputProps, fromInputProps } = useRangeDatepicker({
-        fromDate: sporsmal.min ? new Date(sporsmal.min) : new Date('1900'),
-        toDate: sporsmal.max ? new Date(sporsmal.max) : new Date('2100'),
+        fromDate: sporsmal.min ? toDate(sporsmal.min) : new Date('1900'),
+        toDate: sporsmal.max ? toDate(sporsmal.max) : new Date('2100'),
         defaultMonth: maanedKalenderApnesPa(sporsmal.min, sporsmal.max),
         allowTwoDigitYear: false,
         defaultSelected: field.value
             ? {
-                  from: dayjs(field.value.fom).toDate(),
-                  to: dayjs(field.value.tom).toDate(),
+                  from: toDate(field.value.fom),
+                  to: toDate(field.value.tom),
               }
             : undefined,
         onRangeChange: (range) => {
-            const fom = range?.from ? dayjs(range.from).format('YYYY-MM-DD') : ''
-            const tom = range?.to ? dayjs(range.to).format('YYYY-MM-DD') : ''
+            const fom = range?.from ? format(range.from, 'yyyy-MM-dd') : ''
+            const tom = range?.to ? format(range.to, 'yyyy-MM-dd') : ''
             const nyPeriode = { fom: fom, tom: tom }
             field.onChange(nyPeriode)
         },

--- a/src/components/sporsmal/typer/periode-komp.tsx
+++ b/src/components/sporsmal/typer/periode-komp.tsx
@@ -40,8 +40,8 @@ const PeriodeKomp = ({ sporsmal, index, slettPeriode, antallPerioder }: AllProps
     })
 
     const { datepickerProps, toInputProps, fromInputProps } = useRangeDatepicker({
-        fromDate: sporsmal.min ? toDate(sporsmal.min) : new Date('1900'),
-        toDate: sporsmal.max ? toDate(sporsmal.max) : new Date('2100'),
+        fromDate: sporsmal.min ? toDate(sporsmal.min) : toDate('1900-01-01'),
+        toDate: sporsmal.max ? toDate(sporsmal.max) : toDate('2100-01-01'),
         defaultMonth: maanedKalenderApnesPa(sporsmal.min, sporsmal.max),
         allowTwoDigitYear: false,
         defaultSelected: field.value

--- a/src/components/sporsmal/typer/periode-komp.tsx
+++ b/src/components/sporsmal/typer/periode-komp.tsx
@@ -44,12 +44,13 @@ const PeriodeKomp = ({ sporsmal, index, slettPeriode, antallPerioder }: AllProps
         toDate: sporsmal.max ? toDate(sporsmal.max) : toDate('2100-01-01'),
         defaultMonth: maanedKalenderApnesPa(sporsmal.min, sporsmal.max),
         allowTwoDigitYear: false,
-        defaultSelected: field.value
-            ? {
-                  from: toDate(field.value.fom),
-                  to: toDate(field.value.tom),
-              }
-            : undefined,
+        defaultSelected:
+            field.value?.fom && field.value?.tom
+                ? {
+                      from: toDate(field.value.fom),
+                      to: toDate(field.value.tom),
+                  }
+                : undefined,
         onRangeChange: (range) => {
             const fom = range?.from ? format(range.from, 'yyyy-MM-dd') : ''
             const tom = range?.to ? format(range.to, 'yyyy-MM-dd') : ''

--- a/src/data/mock/data/soknad/friskmeldt-til-arbeidsformidling.ts
+++ b/src/data/mock/data/soknad/friskmeldt-til-arbeidsformidling.ts
@@ -1,5 +1,4 @@
 import { v4 } from 'uuid'
-import dayjs from 'dayjs'
 
 import { RSSoknad } from '../../../../types/rs-types/rs-soknad'
 import { RSSoknadstatusType } from '../../../../types/rs-types/rs-soknadstatus'
@@ -136,7 +135,7 @@ function fortsattArbeidssoker({
 export function jobbsituasjonenDin(opts: { fom: string; tom: string; sisteSoknad: boolean }): RSSporsmal {
     const { fom, tom } = opts
 
-    const periodeTekst = tilLesbarPeriodeMedArstall(dayjs(fom), dayjs(tom))
+    const periodeTekst = tilLesbarPeriodeMedArstall(fom, tom)
 
     const ja: RSSporsmal = {
         id: v4().toString(),
@@ -212,7 +211,7 @@ export function jobbsituasjonenDin(opts: { fom: string; tom: string; sisteSoknad
 export function inntektUnderveis(opts: { fom: string; tom: string }): RSSporsmal {
     const { fom, tom } = opts
 
-    const periodeTekst = tilLesbarPeriodeMedArstall(dayjs(fom), dayjs(tom))
+    const periodeTekst = tilLesbarPeriodeMedArstall(fom, tom)
 
     return {
         id: v4().toString(),
@@ -244,7 +243,7 @@ export function inntektUnderveis(opts: { fom: string; tom: string }): RSSporsmal
 export function reiseTilUtlandet(opts: { fom: string; tom: string }): RSSporsmal {
     const { fom, tom } = opts
 
-    const periodeTekst = tilLesbarPeriodeMedArstall(dayjs(fom), dayjs(tom))
+    const periodeTekst = tilLesbarPeriodeMedArstall(fom, tom)
 
     return {
         id: v4().toString(),

--- a/src/data/mock/data/soknad/soknader-integration.ts
+++ b/src/data/mock/data/soknad/soknader-integration.ts
@@ -143,7 +143,7 @@ export const sendtArbeidsledigKvittering: RSSoknad = {
     fom: '2020-01-01',
     tom: '2020-01-10',
     opprettetDato: '2020-06-23',
-    sendtTilNAVDato: '2020-04-23T11:56:10.624',
+    sendtTilNAVDato: '2020-04-23T09:56:10.624Z',
     sendtTilArbeidsgiverDato: null,
     avbruttDato: null,
     startSykeforlop: '2020-01-01',

--- a/src/data/mock/data/sporsmal/nytt-arbeidsforhold.ts
+++ b/src/data/mock/data/sporsmal/nytt-arbeidsforhold.ts
@@ -1,5 +1,4 @@
 import { v4 } from 'uuid'
-import dayjs from 'dayjs'
 
 import { RSSporsmal } from '../../../../types/rs-types/rs-sporsmal'
 import { tilLesbarPeriodeMedArstall } from '../../../../utils/dato-utils'
@@ -15,7 +14,7 @@ export const nyttArbeidsforholdSporsmal = ({
     tom: string
     fom: string
 }): RSSporsmal => {
-    const periodeTekst = tilLesbarPeriodeMedArstall(dayjs(fom), dayjs(tom))
+    const periodeTekst = tilLesbarPeriodeMedArstall(fom, tom)
 
     return {
         id: v4().toString(),

--- a/src/data/mock/data/testadataGeneratorFunksjoner.ts
+++ b/src/data/mock/data/testadataGeneratorFunksjoner.ts
@@ -1,5 +1,3 @@
-import dayjs from 'dayjs'
-
 import { Sykmelding } from '../../../types/sykmelding'
 import { ArbeidsforholdFraInntektskomponenten } from '../../../types/rs-types/rs-arbeidsforholdfrainntektskomponenten'
 import { RSSoknad } from '../../../types/rs-types/rs-soknad'
@@ -145,7 +143,7 @@ export function skapSoknad(opts: {
 }): RSSoknad {
     const { fom, tom, hovedjobb, sykmeldingId, soknadId } = opts
 
-    const periodeTekst = tilLesbarPeriodeMedArstall(dayjs(fom), dayjs(tom))
+    const periodeTekst = tilLesbarPeriodeMedArstall(fom, tom)
 
     const inntektskilderDataFraInntektskomponenten: ArbeidsforholdFraInntektskomponenten[] = [
         {

--- a/src/utils/dato-utils.test.ts
+++ b/src/utils/dato-utils.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+    fraInputdatoTilJSDato,
+    fraBackendTilDate,
+    tilLesbarDatoMedArstall,
+    tilLesbarPeriodeMedArstall,
+    tilLesbarDatoUtenAarstall,
+    toDate,
+} from './dato-utils'
+
+/**
+ * Tidssone-tester for dato-utils med date-fns/tz.
+ *
+ * Kjør med TZ=America/New_York for å verifisere tidssone-sikkerhet:
+ *   TZ=America/New_York npm run test:ci -- src/utils/dato-utils.test.ts
+ *
+ * Løsning: TZDate med eksplisitt Europe/Oslo tidssone sikrer at
+ * dato-strenger alltid tolkes korrekt uavhengig av brukerens tidssone.
+ */
+
+describe('dato-utils tidssone-sikkerhet (date-fns/tz)', () => {
+    describe('toDate (kjernefunksjon)', () => {
+        it('parser 2020-04-01 til 1. april uansett tidssone', () => {
+            const dato = toDate('2020-04-01')
+            expect(dato.getDate()).toBe(1)
+            expect(dato.getMonth()).toBe(3)
+            expect(dato.getFullYear()).toBe(2020)
+        })
+
+        it('parser 2024-01-01 til 1. januar uansett tidssone', () => {
+            const dato = toDate('2024-01-01')
+            expect(dato.getDate()).toBe(1)
+            expect(dato.getMonth()).toBe(0)
+            expect(dato.getFullYear()).toBe(2024)
+        })
+
+        it('parser 2023-12-31 til 31. desember uansett tidssone', () => {
+            const dato = toDate('2023-12-31')
+            expect(dato.getDate()).toBe(31)
+            expect(dato.getMonth()).toBe(11)
+            expect(dato.getFullYear()).toBe(2023)
+        })
+    })
+
+    describe('tilLesbarDatoMedArstall', () => {
+        it('viser 1. april 2020 for 2020-04-01', () => {
+            expect(tilLesbarDatoMedArstall('2020-04-01')).toBe('1. april 2020')
+        })
+
+        it('viser 1. januar 2024 for 2024-01-01', () => {
+            expect(tilLesbarDatoMedArstall('2024-01-01')).toBe('1. januar 2024')
+        })
+
+        it('viser 31. desember 2023 for 2023-12-31', () => {
+            expect(tilLesbarDatoMedArstall('2023-12-31')).toBe('31. desember 2023')
+        })
+    })
+
+    describe('tilLesbarDatoUtenAarstall', () => {
+        it('viser 1. april for 2020-04-01', () => {
+            expect(tilLesbarDatoUtenAarstall('2020-04-01')).toBe('1. april')
+        })
+    })
+
+    describe('tilLesbarPeriodeMedArstall', () => {
+        it('viser korrekt periode innenfor samme måned', () => {
+            expect(tilLesbarPeriodeMedArstall('2020-04-01', '2020-04-24')).toBe('1. – 24. april 2020')
+        })
+
+        it('viser korrekt periode over månedsskifte', () => {
+            expect(tilLesbarPeriodeMedArstall('2020-04-01', '2020-05-24')).toBe('1. april – 24. mai 2020')
+        })
+
+        it('viser korrekt periode over årsskifte', () => {
+            expect(tilLesbarPeriodeMedArstall('2023-12-01', '2024-01-15')).toBe('1. desember 2023 – 15. januar 2024')
+        })
+    })
+
+    describe('fraBackendTilDate', () => {
+        it('parser 2020-04-01 til 1. april', () => {
+            const dato = fraBackendTilDate('2020-04-01')!
+            expect(dato.getDate()).toBe(1)
+            expect(dato.getMonth()).toBe(3)
+        })
+
+        it('parser 2024-01-01 til 1. januar', () => {
+            const dato = fraBackendTilDate('2024-01-01')!
+            expect(dato.getDate()).toBe(1)
+            expect(dato.getMonth()).toBe(0)
+        })
+    })
+
+    describe('fraInputdatoTilJSDato', () => {
+        it('parser 01.04.2020 til 1. april uansett tidssone', () => {
+            const dato = fraInputdatoTilJSDato('01.04.2020')
+            expect(dato.getDate()).toBe(1)
+            expect(dato.getMonth()).toBe(3)
+            expect(dato.getFullYear()).toBe(2020)
+        })
+
+        it('parser 01.01.2024 til 1. januar uansett tidssone', () => {
+            const dato = fraInputdatoTilJSDato('01.01.2024')
+            expect(dato.getDate()).toBe(1)
+            expect(dato.getMonth()).toBe(0)
+            expect(dato.getFullYear()).toBe(2024)
+        })
+
+        it('parser 31.12.2023 til 31. desember uansett tidssone', () => {
+            const dato = fraInputdatoTilJSDato('31.12.2023')
+            expect(dato.getDate()).toBe(31)
+            expect(dato.getMonth()).toBe(11)
+            expect(dato.getFullYear()).toBe(2023)
+        })
+    })
+})

--- a/src/utils/dato-utils.ts
+++ b/src/utils/dato-utils.ts
@@ -1,6 +1,18 @@
-import dayjs from 'dayjs'
+import { differenceInDays, format, isSameMonth, isSameYear, isAfter, isBefore, addDays } from 'date-fns'
+import { TZDate } from '@date-fns/tz'
 
 import { Sporsmal } from '../types/types'
+
+const OSLO = 'Europe/Oslo'
+
+/**
+ * Parser en ISO-datostreng til en Date i Oslo-tidssone.
+ * Unngår problemet med new Date('2020-01-01') som gir UTC midnight
+ * og dermed feil dato i tidssoner vest for UTC.
+ */
+export function toDate(date: string): Date {
+    return new TZDate(date, OSLO)
+}
 
 export const fraInputdatoTilJSDato = (inputDato: any) => {
     const datoSplit = inputDato.split('.')
@@ -9,7 +21,7 @@ export const fraInputdatoTilJSDato = (inputDato: any) => {
         ar = `20${ar}`
     }
     const s = `${ar}-${datoSplit[1]}-${datoSplit[0]}`
-    return new Date(s)
+    return toDate(s)
 }
 
 export const maaneder = [
@@ -29,16 +41,17 @@ export const maaneder = [
 const SKILLETEGN_PERIODE = '–'
 
 export const tilBackendDato = (datoArg: string) => {
-    return dayjs(datoArg).format('YYYY-MM-DD')
+    return format(toDate(datoArg), 'yyyy-MM-dd')
 }
 
 export const fraBackendTilDate = (datoArg: string) => {
-    if (datoArg && datoArg.match(RegExp('\\d{4}-\\d{2}-\\d{2}'))) return dayjs(datoArg).toDate()
+    if (datoArg && datoArg.match(RegExp('\\d{4}-\\d{2}-\\d{2}'))) return toDate(datoArg)
 }
 
 export const tilLesbarDatoUtenAarstall = (datoArg: any): string => {
     if (datoArg) {
-        const dato = dayjsToDate(datoArg)!
+        const dato = ensureDate(datoArg)
+        if (!dato) return ''
         const dag = dato.getDate()
         const manedIndex = dato.getMonth()
         const maned = maaneder[manedIndex]
@@ -47,13 +60,25 @@ export const tilLesbarDatoUtenAarstall = (datoArg: any): string => {
     return ''
 }
 
+function ensureDate(val: any): Date | undefined {
+    if (!val) return undefined
+    if (val instanceof Date) return val
+    if (typeof val === 'string') return toDate(val)
+    // Handle dayjs-like objects from mock data
+    if (typeof val === 'object' && typeof val.toDate === 'function') return val.toDate()
+    return undefined
+}
+
 export const tilLesbarDatoMedArstall = (datoArg: any) => {
-    return datoArg ? `${tilLesbarDatoUtenAarstall(dayjsToDate(datoArg))} ${dayjsToDate(datoArg)!.getFullYear()}` : null
+    if (!datoArg) return null
+    const dato = ensureDate(datoArg)
+    if (!dato) return null
+    return `${tilLesbarDatoUtenAarstall(dato)} ${dato.getFullYear()}`
 }
 
 export const tilLesbarPeriodeMedArstall = (fomArg: any, tomArg: any) => {
-    const fom = dayjsToDate(fomArg)
-    const tom = dayjsToDate(tomArg)
+    const fom = ensureDate(fomArg)
+    const tom = ensureDate(tomArg)
     const erSammeAar = fom?.getFullYear() === tom?.getFullYear()
     const erSammeMaaned = fom?.getMonth() === tom?.getMonth()
     return erSammeAar && erSammeMaaned
@@ -64,8 +89,8 @@ export const tilLesbarPeriodeMedArstall = (fomArg: any, tomArg: any) => {
 }
 
 export const tilLesbarPeriodeUtenArstall = (fomArg: any, tomArg: any) => {
-    const fom = dayjsToDate(fomArg)!
-    const tom = dayjsToDate(tomArg)!
+    const fom = ensureDate(fomArg)!
+    const tom = ensureDate(tomArg)!
     const erSammeMaaned = fom.getMonth() === tom.getMonth()
     return erSammeMaaned
         ? `${fom.getDate()}. ${SKILLETEGN_PERIODE} ${tilLesbarDatoUtenAarstall(tom)}`
@@ -73,55 +98,55 @@ export const tilLesbarPeriodeUtenArstall = (fomArg: any, tomArg: any) => {
 }
 
 export const getDuration = (from: any, to: any) => {
-    return dayjs(to).diff(from, 'days') + 1
+    const fromDate = typeof from === 'string' ? toDate(from) : from
+    const toDateVal = typeof to === 'string' ? toDate(to) : to
+    return differenceInDays(toDateVal, fromDate) + 1
 }
 
 export const ukeDatoListe = (min: string, max: string) => {
-    const ukeListe = []
-    let dato = dayjs(min)
-    while (dato.toDate() <= dayjs(max).toDate()) {
+    const ukeListe: Date[] = []
+    let dato = toDate(min)
+    const maxDate = toDate(max)
+    while (dato <= maxDate) {
         ukeListe.push(dato)
-        dato = dato.add(1, 'day')
+        dato = addDays(dato, 1)
     }
     return ukeListe
 }
 
 export const dayjsToDate = (dato: string) => {
-    return dato !== null ? dayjs(dato).toDate() : undefined
+    return dato !== null ? toDate(dato) : undefined
 }
 
 export const parseDate = (dato: string) => {
-    return dayjs(dato).toDate()
+    return toDate(dato)
 }
 
 export const sendtForMerEnn30DagerSiden = (sendtTilArbeidsgiverDato?: Date, sendtTilNAVDato?: Date) => {
+    const now = new TZDate(new Date(), OSLO)
     let dagerSidenArb = true
     let dagerSidenNav = true
     if (sendtTilArbeidsgiverDato) {
-        dagerSidenArb = dayjs(new Date()).diff(dayjs(sendtTilArbeidsgiverDato), 'day') > 30
+        dagerSidenArb = differenceInDays(now, sendtTilArbeidsgiverDato) > 30
     }
     if (sendtTilNAVDato) {
-        dagerSidenNav = dayjs(new Date()).diff(dayjs(sendtTilNAVDato), 'day') > 30
+        dagerSidenNav = differenceInDays(now, sendtTilNAVDato) > 30
     }
     return dagerSidenArb && dagerSidenNav
 }
 
 export const sammeMnd = (sporsmal: Sporsmal): boolean => {
-    const firstMonth = dayjs(sporsmal.min!).month()
-    const lastMonth = dayjs(sporsmal.max!).month()
-    return firstMonth === lastMonth
+    return isSameMonth(toDate(sporsmal.min!), toDate(sporsmal.max!))
 }
 
 export const sammeAar = (sporsmal: Sporsmal): boolean => {
-    const firstYear = dayjs(sporsmal.min!).year().toString()
-    const lastYear = dayjs(sporsmal.max!).year().toString()
-    return firstYear === lastYear
+    return isSameYear(toDate(sporsmal.min!), toDate(sporsmal.max!))
 }
 
 export function kalkulerStartsmaneden(sporsmal: Sporsmal) {
-    const idag = dayjs()
-    if (idag.isAfter(sporsmal.max) || idag.isBefore(sporsmal.min)) {
+    const idag = new TZDate(new Date(), OSLO)
+    if (isAfter(idag, toDate(sporsmal.max!)) || isBefore(idag, toDate(sporsmal.min!))) {
         return fraBackendTilDate(sporsmal.max!)
     }
-    return fraBackendTilDate(idag.toString())
+    return idag
 }

--- a/src/utils/dato-utils.ts
+++ b/src/utils/dato-utils.ts
@@ -1,17 +1,23 @@
-import { differenceInDays, format, isSameMonth, isSameYear, isAfter, isBefore, addDays } from 'date-fns'
+import { differenceInDays, format, isSameMonth, isSameYear, isAfter, isBefore, addDays, parseISO } from 'date-fns'
 import { TZDate } from '@date-fns/tz'
 
 import { Sporsmal } from '../types/types'
 
 const OSLO = 'Europe/Oslo'
 
-/**
- * Parser en ISO-datostreng til en Date i Oslo-tidssone.
- * Unngår problemet med new Date('2020-01-01') som gir UTC midnight
- * og dermed feil dato i tidssoner vest for UTC.
- */
-export function toDate(date: string): Date {
-    return new TZDate(date, OSLO)
+// Parser dato-streng til Date med riktig tidssone.
+// Strenger med tz-info (Z eller ±HH:MM) parses korrekt med parseISO.
+// Strenger uten tz-info (dato og datetime) tolkes som Europe/Oslo for å unngå
+// at UTC-midnatt forskyver datoen for brukere vest for UTC.
+export function toDate(date: string, defaultTimezone = OSLO): Date {
+    if (isoTimestampHarTidssone(date)) {
+        return parseISO(date)
+    }
+    return new TZDate(date, defaultTimezone)
+}
+
+function isoTimestampHarTidssone(iso: string): boolean {
+    return /([Zz]|[+-]\d{2}:\d{2})$/.test(iso)
 }
 
 /** Nåtidspunkt i Oslo-tidssone. */

--- a/src/utils/dato-utils.ts
+++ b/src/utils/dato-utils.ts
@@ -76,9 +76,6 @@ function ensureDate(val: any): Date | undefined {
     if (!val) return undefined
     if (val instanceof Date) return val
     if (typeof val === 'string') return toDate(val)
-    // Midlertidig bridge for dayjs-objekter i mock-data (fjernes når PR #4038 merger).
-    // Bruker .format() i stedet for .toDate() for å unngå UTC-midnatt-problemet.
-    if (typeof val === 'object' && typeof val.format === 'function') return toDate(val.format('YYYY-MM-DD'))
     return undefined
 }
 

--- a/src/utils/dato-utils.ts
+++ b/src/utils/dato-utils.ts
@@ -76,8 +76,9 @@ function ensureDate(val: any): Date | undefined {
     if (!val) return undefined
     if (val instanceof Date) return val
     if (typeof val === 'string') return toDate(val)
-    // Handle dayjs-like objects from mock data
-    if (typeof val === 'object' && typeof val.toDate === 'function') return val.toDate()
+    // Midlertidig bridge for dayjs-objekter i mock-data (fjernes når PR #4038 merger).
+    // Bruker .format() i stedet for .toDate() for å unngå UTC-midnatt-problemet.
+    if (typeof val === 'object' && typeof val.format === 'function') return toDate(val.format('YYYY-MM-DD'))
     return undefined
 }
 

--- a/src/utils/dato-utils.ts
+++ b/src/utils/dato-utils.ts
@@ -115,7 +115,7 @@ export const ukeDatoListe = (min: string, max: string) => {
 }
 
 export const dayjsToDate = (dato: string) => {
-    return dato !== null ? toDate(dato) : undefined
+    return dato ? toDate(dato) : undefined
 }
 
 export const parseDate = (dato: string) => {

--- a/src/utils/dato-utils.ts
+++ b/src/utils/dato-utils.ts
@@ -14,6 +14,18 @@ export function toDate(date: string): Date {
     return new TZDate(date, OSLO)
 }
 
+/** Nåtidspunkt i Oslo-tidssone. */
+export function now(): Date {
+    return new TZDate(new Date(), OSLO)
+}
+
+/** Bygger en dato fra år, måned og dag i Oslo-tidssone. */
+export function osloDate(year: number, month: number, day: number): Date {
+    const m = String(month).padStart(2, '0')
+    const d = String(day).padStart(2, '0')
+    return new TZDate(`${year}-${m}-${d}`, OSLO)
+}
+
 export const fraInputdatoTilJSDato = (inputDato: any) => {
     const datoSplit = inputDato.split('.')
     let ar = datoSplit[2]
@@ -123,14 +135,14 @@ export const parseDate = (dato: string) => {
 }
 
 export const sendtForMerEnn30DagerSiden = (sendtTilArbeidsgiverDato?: Date, sendtTilNAVDato?: Date) => {
-    const now = new TZDate(new Date(), OSLO)
+    const iDag = now()
     let dagerSidenArb = true
     let dagerSidenNav = true
     if (sendtTilArbeidsgiverDato) {
-        dagerSidenArb = differenceInDays(now, sendtTilArbeidsgiverDato) > 30
+        dagerSidenArb = differenceInDays(iDag, sendtTilArbeidsgiverDato) > 30
     }
     if (sendtTilNAVDato) {
-        dagerSidenNav = differenceInDays(now, sendtTilNAVDato) > 30
+        dagerSidenNav = differenceInDays(iDag, sendtTilNAVDato) > 30
     }
     return dagerSidenArb && dagerSidenNav
 }
@@ -144,7 +156,7 @@ export const sammeAar = (sporsmal: Sporsmal): boolean => {
 }
 
 export function kalkulerStartsmaneden(sporsmal: Sporsmal) {
-    const idag = new TZDate(new Date(), OSLO)
+    const idag = now()
     if (isAfter(idag, toDate(sporsmal.max!)) || isBefore(idag, toDate(sporsmal.min!))) {
         return fraBackendTilDate(sporsmal.max!)
     }

--- a/src/utils/helligdager-utils.test.ts
+++ b/src/utils/helligdager-utils.test.ts
@@ -1,112 +1,119 @@
-import dayjs from 'dayjs'
 import { test, expect } from 'vitest'
 
+import { toDate } from './dato-utils'
 import { andrePinsedag, easterSunday, førstePinsedag, kristiHimmelfartsdag } from './helligdager-utils'
 
+function expectSameDate(actual: Date, expectedIso: string) {
+    const expected = toDate(expectedIso)
+    expect(actual.getFullYear()).toBe(expected.getFullYear())
+    expect(actual.getMonth()).toBe(expected.getMonth())
+    expect(actual.getDate()).toBe(expected.getDate())
+}
+
 test('Påske 2020', () => {
-    expect(easterSunday(2020)).toEqual(dayjs('2020.04.12'))
+    expectSameDate(easterSunday(2020), '2020-04-12')
 })
 
 test('Påske 2021', () => {
-    expect(easterSunday(2021)).toEqual(dayjs('2021.04.04'))
+    expectSameDate(easterSunday(2021), '2021-04-04')
 })
 
 test('Påske 2022', () => {
-    expect(easterSunday(2022)).toEqual(dayjs('2022.04.17'))
+    expectSameDate(easterSunday(2022), '2022-04-17')
 })
 
 test('Påske 2023', () => {
-    expect(easterSunday(2023)).toEqual(dayjs('2023.04.09'))
+    expectSameDate(easterSunday(2023), '2023-04-09')
 })
 
 test('Påske 2024', () => {
-    expect(easterSunday(2024)).toEqual(dayjs('2024.03.31'))
+    expectSameDate(easterSunday(2024), '2024-03-31')
 })
 
 test('Påske 2025', () => {
-    expect(easterSunday(2025)).toEqual(dayjs('2025.04.20'))
+    expectSameDate(easterSunday(2025), '2025-04-20')
 })
 
 test('Påske 2026', () => {
-    expect(easterSunday(2026)).toEqual(dayjs('2026.04.05'))
+    expectSameDate(easterSunday(2026), '2026-04-05')
 })
 
 test('Påske 2027', () => {
-    expect(easterSunday(2027)).toEqual(dayjs('2027.03.28'))
+    expectSameDate(easterSunday(2027), '2027-03-28')
 })
 
 test('Påske 2028', () => {
-    expect(easterSunday(2028)).toEqual(dayjs('2028.04.16'))
+    expectSameDate(easterSunday(2028), '2028-04-16')
 })
 
 test('Påske 2029', () => {
-    expect(easterSunday(2029)).toEqual(dayjs('2029.04.01'))
+    expectSameDate(easterSunday(2029), '2029-04-01')
 })
 
 test('Påske 2030', () => {
-    expect(easterSunday(2030)).toEqual(dayjs('2030.04.21'))
+    expectSameDate(easterSunday(2030), '2030-04-21')
 })
 
 test('Kristi himmelfartsdag 2020', () => {
-    expect(kristiHimmelfartsdag(2020)).toEqual(dayjs('2020.05.21'))
+    expectSameDate(kristiHimmelfartsdag(2020), '2020-05-21')
 })
 
 test('Kristi himmelfartsdag 2021', () => {
-    expect(kristiHimmelfartsdag(2021)).toEqual(dayjs('2021.05.13'))
+    expectSameDate(kristiHimmelfartsdag(2021), '2021-05-13')
 })
 
 test('Kristi himmelfartsdag 2022', () => {
-    expect(kristiHimmelfartsdag(2022)).toEqual(dayjs('2022.05.26'))
+    expectSameDate(kristiHimmelfartsdag(2022), '2022-05-26')
 })
 
 test('Kristi himmelfartsdag 2023', () => {
-    expect(kristiHimmelfartsdag(2023)).toEqual(dayjs('2023.05.18'))
+    expectSameDate(kristiHimmelfartsdag(2023), '2023-05-18')
 })
 
 test('Kristi himmelfartsdag 2024', () => {
-    expect(kristiHimmelfartsdag(2024)).toEqual(dayjs('2024.05.09'))
+    expectSameDate(kristiHimmelfartsdag(2024), '2024-05-09')
 })
 
 test('Kristi himmelfartsdag 2025', () => {
-    expect(kristiHimmelfartsdag(2025)).toEqual(dayjs('2025.05.29'))
+    expectSameDate(kristiHimmelfartsdag(2025), '2025-05-29')
 })
 
 test('første pinsedag 2020', () => {
-    expect(førstePinsedag(2020)).toEqual(dayjs('2020.05.31'))
+    expectSameDate(førstePinsedag(2020), '2020-05-31')
 })
 
 test('første pinsedag 2021', () => {
-    expect(førstePinsedag(2021)).toEqual(dayjs('2021.05.23'))
+    expectSameDate(førstePinsedag(2021), '2021-05-23')
 })
 
 test('første pinsedag 2022', () => {
-    expect(førstePinsedag(2022)).toEqual(dayjs('2022.06.05'))
+    expectSameDate(førstePinsedag(2022), '2022-06-05')
 })
 
 test('første pinsedag 2023', () => {
-    expect(førstePinsedag(2023)).toEqual(dayjs('2023.05.28'))
+    expectSameDate(førstePinsedag(2023), '2023-05-28')
 })
 
 test('første pinsedag 2024', () => {
-    expect(førstePinsedag(2024)).toEqual(dayjs('2024.05.19'))
+    expectSameDate(førstePinsedag(2024), '2024-05-19')
 })
 
 test('første pinsedag 2025', () => {
-    expect(førstePinsedag(2025)).toEqual(dayjs('2025.06.08'))
+    expectSameDate(førstePinsedag(2025), '2025-06-08')
 })
 
 test('andre pinsedag 2022', () => {
-    expect(andrePinsedag(2022)).toEqual(dayjs('2022.06.06'))
+    expectSameDate(andrePinsedag(2022), '2022-06-06')
 })
 
 test('andre pinsedag 2023', () => {
-    expect(andrePinsedag(2023)).toEqual(dayjs('2023.05.29'))
+    expectSameDate(andrePinsedag(2023), '2023-05-29')
 })
 
 test('andre pinsedag 2024', () => {
-    expect(andrePinsedag(2024)).toEqual(dayjs('2024.05.20'))
+    expectSameDate(andrePinsedag(2024), '2024-05-20')
 })
 
 test('andre pinsedag 2025', () => {
-    expect(andrePinsedag(2025)).toEqual(dayjs('2025.06.09'))
+    expectSameDate(andrePinsedag(2025), '2025-06-09')
 })

--- a/src/utils/helligdager-utils.ts
+++ b/src/utils/helligdager-utils.ts
@@ -1,4 +1,4 @@
-import { addDays, subDays, isSameDay, isBefore, isAfter, getDay } from 'date-fns'
+import { addDays, subDays, isSameDay, isBefore, isAfter, isSaturday, isSunday } from 'date-fns'
 
 import { osloDate } from './dato-utils'
 
@@ -98,8 +98,8 @@ export function rodeUkeDagerIPerioden(min?: Date, max?: Date) {
     roodeDager.forEach((dag) => {
         if (
             (isSameDay(min, dag) || isSameDay(max, dag) || (isBefore(min, dag) && isAfter(max, dag))) &&
-            getDay(dag) !== 0 &&
-            getDay(dag) !== 6
+            !isSaturday(dag) &&
+            !isSunday(dag)
         ) {
             rodDagErIUkeDag = true
         }

--- a/src/utils/helligdager-utils.ts
+++ b/src/utils/helligdager-utils.ts
@@ -1,6 +1,9 @@
-import dayjs, { Dayjs } from 'dayjs'
+import { addDays, subDays, isSameDay, isBefore, isAfter, getDay } from 'date-fns'
+import { TZDate } from '@date-fns/tz'
 
-export function easterSunday(InputYear: number): Dayjs {
+const OSLO = 'Europe/Oslo'
+
+export function easterSunday(InputYear: number): Date {
     const a = InputYear % 19
     const b = Math.floor(InputYear / 100)
     const c = InputYear % 100
@@ -17,14 +20,16 @@ export function easterSunday(InputYear: number): Dayjs {
     let p = (h + l - 7 * m + 114) % 31
     p++
 
-    return dayjs(`${InputYear}-${n}-${p}`)
+    const month = String(n).padStart(2, '0')
+    const day = String(p).padStart(2, '0')
+    return new TZDate(`${InputYear}-${month}-${day}`, OSLO)
 }
 
-function paskedager(inputYear: number): Dayjs[] {
+function paskedager(inputYear: number): Date[] {
     const forstePaskeDag = easterSunday(inputYear)
-    const andrePaskeDag = forstePaskeDag.add(1, 'days')
-    const langfredag = forstePaskeDag.subtract(2, 'days')
-    const skjertorsdag = forstePaskeDag.subtract(3, 'days')
+    const andrePaskeDag = addDays(forstePaskeDag, 1)
+    const langfredag = subDays(forstePaskeDag, 2)
+    const skjertorsdag = subDays(forstePaskeDag, 3)
 
     return [skjertorsdag, langfredag, forstePaskeDag, andrePaskeDag]
 }
@@ -34,13 +39,11 @@ export function innenforPaske(min?: Date, max?: Date) {
         return false
     }
 
-    const start = dayjs(min)
-    const slutt = dayjs(max)
-    const paske = paskedager(start.year())
+    const paske = paskedager(min.getFullYear())
     let erInnenforPaske = false
 
     paske.forEach((dag) => {
-        if (start.isSame(dag, 'day') || slutt.isSame(dag, 'day') || (start.isBefore(dag) && slutt.isAfter(dag))) {
+        if (isSameDay(min, dag) || isSameDay(max, dag) || (isBefore(min, dag) && isAfter(max, dag))) {
             erInnenforPaske = true
         }
     })
@@ -49,29 +52,29 @@ export function innenforPaske(min?: Date, max?: Date) {
 }
 
 export const førsteNyttårsdag = (inputYear: number) => {
-    return dayjs(`${inputYear}-1-1`)
-} // New Year's Day
+    return new TZDate(`${inputYear}-01-01`, OSLO)
+}
 export const arbeidernesDag = (inputYear: number) => {
-    return dayjs(`${inputYear}-5-1`)
-} // labor day
+    return new TZDate(`${inputYear}-05-01`, OSLO)
+}
 export const grunnlovsdagen = (inputYear: number) => {
-    return dayjs(`${inputYear}-5-17`)
-} // constitution day
+    return new TZDate(`${inputYear}-05-17`, OSLO)
+}
 export const kristiHimmelfartsdag = (inputYear: number) => {
-    return easterSunday(inputYear).add(39, 'days')
-} // ascension day
+    return addDays(easterSunday(inputYear), 39)
+}
 export const førstePinsedag = (inputYear: number) => {
-    return easterSunday(inputYear).add(49, 'days')
-} // white sunday
+    return addDays(easterSunday(inputYear), 49)
+}
 export const andrePinsedag = (inputYear: number) => {
-    return easterSunday(inputYear).add(50, 'days')
-} // white monday
+    return addDays(easterSunday(inputYear), 50)
+}
 export const førsteJuledag = (inputYear: number) => {
-    return dayjs(`${inputYear}-12-25`)
-} // Christmas day
+    return new TZDate(`${inputYear}-12-25`, OSLO)
+}
 export const andreJuledag = (inputYear: number) => {
-    return dayjs(`${inputYear}-12-26`)
-} // boxing day
+    return new TZDate(`${inputYear}-12-26`, OSLO)
+}
 
 export const rodeDager = (inputYear: number) => {
     const rodeDagerMinusPaske = [
@@ -92,16 +95,14 @@ export function rodeUkeDagerIPerioden(min?: Date, max?: Date) {
         return false
     }
 
-    const start = dayjs(min)
-    const slutt = dayjs(max)
-    const roodeDager = rodeDager(start.year())
+    const roodeDager = rodeDager(min.getFullYear())
     let rodDagErIUkeDag = false
 
     roodeDager.forEach((dag) => {
         if (
-            (start.isSame(dag, 'day') || slutt.isSame(dag, 'day') || (start.isBefore(dag) && slutt.isAfter(dag))) &&
-            dag.day() !== 0 &&
-            dag.day() !== 6
+            (isSameDay(min, dag) || isSameDay(max, dag) || (isBefore(min, dag) && isAfter(max, dag))) &&
+            getDay(dag) !== 0 &&
+            getDay(dag) !== 6
         ) {
             rodDagErIUkeDag = true
         }

--- a/src/utils/helligdager-utils.ts
+++ b/src/utils/helligdager-utils.ts
@@ -1,7 +1,6 @@
 import { addDays, subDays, isSameDay, isBefore, isAfter, getDay } from 'date-fns'
-import { TZDate } from '@date-fns/tz'
 
-const OSLO = 'Europe/Oslo'
+import { osloDate } from './dato-utils'
 
 export function easterSunday(InputYear: number): Date {
     const a = InputYear % 19
@@ -20,9 +19,7 @@ export function easterSunday(InputYear: number): Date {
     let p = (h + l - 7 * m + 114) % 31
     p++
 
-    const month = String(n).padStart(2, '0')
-    const day = String(p).padStart(2, '0')
-    return new TZDate(`${InputYear}-${month}-${day}`, OSLO)
+    return osloDate(InputYear, n, p)
 }
 
 function paskedager(inputYear: number): Date[] {
@@ -52,13 +49,13 @@ export function innenforPaske(min?: Date, max?: Date) {
 }
 
 export const førsteNyttårsdag = (inputYear: number) => {
-    return new TZDate(`${inputYear}-01-01`, OSLO)
+    return osloDate(inputYear, 1, 1)
 }
 export const arbeidernesDag = (inputYear: number) => {
-    return new TZDate(`${inputYear}-05-01`, OSLO)
+    return osloDate(inputYear, 5, 1)
 }
 export const grunnlovsdagen = (inputYear: number) => {
-    return new TZDate(`${inputYear}-05-17`, OSLO)
+    return osloDate(inputYear, 5, 17)
 }
 export const kristiHimmelfartsdag = (inputYear: number) => {
     return addDays(easterSunday(inputYear), 39)
@@ -70,10 +67,10 @@ export const andrePinsedag = (inputYear: number) => {
     return addDays(easterSunday(inputYear), 50)
 }
 export const førsteJuledag = (inputYear: number) => {
-    return new TZDate(`${inputYear}-12-25`, OSLO)
+    return osloDate(inputYear, 12, 25)
 }
 export const andreJuledag = (inputYear: number) => {
-    return new TZDate(`${inputYear}-12-26`, OSLO)
+    return osloDate(inputYear, 12, 26)
 }
 
 export const rodeDager = (inputYear: number) => {

--- a/src/utils/sporsmal/valider-arbeidsgrad.ts
+++ b/src/utils/sporsmal/valider-arbeidsgrad.ts
@@ -4,7 +4,7 @@ import { useFormContext } from 'react-hook-form'
 import { hentPeriodeListe, hentSvar } from '../../components/sporsmal/hent-svar'
 import { RSSoknadstype } from '../../types/rs-types/rs-soknadstype'
 import { Sporsmal } from '../../types/types'
-import { toDate, ukeDatoListe } from '../dato-utils'
+import { ukeDatoListe } from '../dato-utils'
 import { finnHovedSporsmal, hentSporsmal, hentUndersporsmal } from '../soknad-utils'
 import { getLedetekst, tekst } from '../tekster'
 import { useSoknadMedDetaljer } from '../../hooks/useSoknadMedDetaljer'
@@ -24,12 +24,14 @@ const useValiderArbeidsgrad = (sporsmal: Sporsmal) => {
     const periode = valgtSoknad.soknadPerioder[hovedSporsmal!.tagIndex!]
     const periodeDager = ukeDatoListe(periode.fom.toString(), periode.tom.toString())
 
+    const tilbakeDato = tilbake instanceof Date ? tilbake : undefined
+
     const sykedagerForFrilansere = () => {
         return periodeDager
             .filter((dag) => getDay(dag) !== 0 && getDay(dag) !== 6)
             .filter((dag) => {
-                if (tilbake !== '') {
-                    return isBeforeDate(dag, toDate(tilbake))
+                if (tilbakeDato) {
+                    return isBeforeDate(dag, tilbakeDato)
                 } else {
                     return true
                 }
@@ -49,8 +51,8 @@ const useValiderArbeidsgrad = (sporsmal: Sporsmal) => {
             .filter((dag) => !ekskluderteDager.find((ekskludertDag) => ekskludertDag.getTime() === dag.getTime()))
             .filter((dag) => getDay(dag) !== 0 && getDay(dag) !== 6)
             .filter((dag) => {
-                if (tilbake !== '') {
-                    return isBeforeDate(dag, toDate(tilbake))
+                if (tilbakeDato) {
+                    return isBeforeDate(dag, tilbakeDato)
                 } else {
                     return true
                 }
@@ -61,9 +63,13 @@ const useValiderArbeidsgrad = (sporsmal: Sporsmal) => {
         const faktiskArbeidsGrad = beregnGrad()
         const forventetArbeidsGrad = 1.0 - periode.grad / 100
 
+        if (faktiskArbeidsGrad === undefined) {
+            return true
+        }
+
         return faktiskArbeidsGrad < forventetArbeidsGrad
             ? getLedetekst(tekst('soknad.feilmelding.MINDRE_TIMER_ENN_FORVENTET'), {
-                  '%PROSENT%': Math.floor(faktiskArbeidsGrad! * 100),
+                  '%PROSENT%': Math.floor(faktiskArbeidsGrad * 100),
               })
             : true
     }
@@ -107,7 +113,15 @@ const useValiderArbeidsgrad = (sporsmal: Sporsmal) => {
         const timerPerUke = timerPerUkeVanligvis()
         const faktiskTimer = timerDennePerioden()
 
-        if (!faktiskTimer || !timerPerUke) {
+        if (
+            faktiskTimer === undefined ||
+            timerPerUke === undefined ||
+            !Number.isFinite(faktiskTimer) ||
+            !Number.isFinite(timerPerUke) ||
+            !Number.isFinite(uker) ||
+            uker <= 0 ||
+            timerPerUke <= 0
+        ) {
             return undefined
         } else {
             return faktiskTimer / uker / timerPerUke
@@ -130,6 +144,16 @@ const useValiderArbeidsgrad = (sporsmal: Sporsmal) => {
         const dagerIPeriode = faktiskeSykedager.length
 
         const uker = dagerIPeriode / 5
+
+        if (
+            !Number.isFinite(faktiskTimer) ||
+            !Number.isFinite(timerPerUke) ||
+            !Number.isFinite(uker) ||
+            uker <= 0 ||
+            timerPerUke <= 0
+        ) {
+            return undefined
+        }
 
         return faktiskTimer / uker / timerPerUke
     }

--- a/src/utils/sporsmal/valider-arbeidsgrad.ts
+++ b/src/utils/sporsmal/valider-arbeidsgrad.ts
@@ -1,4 +1,4 @@
-import { getDay, isBefore as isBeforeDate } from 'date-fns'
+import { isBefore as isBeforeDate, isSaturday, isSunday } from 'date-fns'
 import { useFormContext } from 'react-hook-form'
 
 import { hentPeriodeListe, hentSvar } from '../../components/sporsmal/hent-svar'
@@ -28,7 +28,7 @@ const useValiderArbeidsgrad = (sporsmal: Sporsmal) => {
 
     const sykedagerForFrilansere = () => {
         return periodeDager
-            .filter((dag) => getDay(dag) !== 0 && getDay(dag) !== 6)
+            .filter((dag) => !isSaturday(dag) && !isSunday(dag))
             .filter((dag) => {
                 if (tilbakeDato) {
                     return isBeforeDate(dag, tilbakeDato)
@@ -49,7 +49,7 @@ const useValiderArbeidsgrad = (sporsmal: Sporsmal) => {
 
         return periodeDager
             .filter((dag) => !ekskluderteDager.find((ekskludertDag) => ekskludertDag.getTime() === dag.getTime()))
-            .filter((dag) => getDay(dag) !== 0 && getDay(dag) !== 6)
+            .filter((dag) => !isSaturday(dag) && !isSunday(dag))
             .filter((dag) => {
                 if (tilbakeDato) {
                     return isBeforeDate(dag, tilbakeDato)

--- a/src/utils/sporsmal/valider-arbeidsgrad.ts
+++ b/src/utils/sporsmal/valider-arbeidsgrad.ts
@@ -1,10 +1,10 @@
-import dayjs from 'dayjs'
+import { getDay, isBefore as isBeforeDate } from 'date-fns'
 import { useFormContext } from 'react-hook-form'
 
 import { hentPeriodeListe, hentSvar } from '../../components/sporsmal/hent-svar'
 import { RSSoknadstype } from '../../types/rs-types/rs-soknadstype'
 import { Sporsmal } from '../../types/types'
-import { ukeDatoListe } from '../dato-utils'
+import { toDate, ukeDatoListe } from '../dato-utils'
 import { finnHovedSporsmal, hentSporsmal, hentUndersporsmal } from '../soknad-utils'
 import { getLedetekst, tekst } from '../tekster'
 import { useSoknadMedDetaljer } from '../../hooks/useSoknadMedDetaljer'
@@ -26,10 +26,10 @@ const useValiderArbeidsgrad = (sporsmal: Sporsmal) => {
 
     const sykedagerForFrilansere = () => {
         return periodeDager
-            .filter((dag) => dag.day() !== 0 && dag.day() !== 6)
+            .filter((dag) => getDay(dag) !== 0 && getDay(dag) !== 6)
             .filter((dag) => {
                 if (tilbake !== '') {
-                    return dag < dayjs(tilbake)
+                    return isBeforeDate(dag, toDate(tilbake))
                 } else {
                     return true
                 }
@@ -47,10 +47,10 @@ const useValiderArbeidsgrad = (sporsmal: Sporsmal) => {
 
         return periodeDager
             .filter((dag) => !ekskluderteDager.find((ekskludertDag) => ekskludertDag.toString() === dag.toString()))
-            .filter((dag) => dag.day() !== 0 && dag.day() !== 6)
+            .filter((dag) => getDay(dag) !== 0 && getDay(dag) !== 6)
             .filter((dag) => {
                 if (tilbake !== '') {
-                    return dag < dayjs(tilbake)
+                    return isBeforeDate(dag, toDate(tilbake))
                 } else {
                     return true
                 }

--- a/src/utils/sporsmal/valider-arbeidsgrad.ts
+++ b/src/utils/sporsmal/valider-arbeidsgrad.ts
@@ -46,7 +46,7 @@ const useValiderArbeidsgrad = (sporsmal: Sporsmal) => {
         const ekskluderteDager = [feriedager, permisjonsdager].flat()
 
         return periodeDager
-            .filter((dag) => !ekskluderteDager.find((ekskludertDag) => ekskludertDag.toString() === dag.toString()))
+            .filter((dag) => !ekskluderteDager.find((ekskludertDag) => ekskludertDag.getTime() === dag.getTime()))
             .filter((dag) => getDay(dag) !== 0 && getDay(dag) !== 6)
             .filter((dag) => {
                 if (tilbake !== '') {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
     plugins: [react()],
+    envDir: '/tmp/vitest-env-dir',
     test: {
         exclude: ['**/node_modules/**', '**/playwright/**'],
         environment: 'jsdom',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,8 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
     plugins: [react()],
+    // Peker på en ikke-eksisterende katalog slik at ingen lokal .env-fil
+    // (som kan sette TZ=... el.) utilsiktet påvirker tidssone-sensitive tester.
     envDir: '/tmp/vitest-env-dir',
     test: {
         exclude: ['**/node_modules/**', '**/playwright/**'],


### PR DESCRIPTION
## Problem

Brukere i tidssoner vest for UTC (f.eks. New York, UTC-5) opplever at datoer forskyves én dag bakover. Årsak: `new Date('2020-01-01')` tolkes som UTC midnight per ECMAScript-spesifikasjonen (§21.4.3.2). I UTC-5 gir `getDate()` 31. desember i stedet for 1. januar.

Dette er et kjent problem — nøyaktig samme bug er rapportert i [react-day-picker #1389](https://github.com/gpbl/react-day-picker/issues/1389) og fikset i `ditt-sykefravaer` (commit 09af785) og `spinnsyn-frontend` (PR #3173).

## Løsning

Migrerer kjernefunksjonene fra `dayjs` til `date-fns` + `@date-fns/tz` med eksplisitt `TZDate('Europe/Oslo')`. Dette gjør tidssone-intensjonen eksplisitt i koden, konsistent med resten av teamets apper.

```typescript
// Før — bug i vest-tidssoner
fromDate: new Date(sporsmal.min)  // UTC midnight → feil dag

// Etter — eksplisitt Oslo-tidssone
fromDate: toDate(sporsmal.min)    // TZDate(..., 'Europe/Oslo') → alltid korrekt
```

## Endringer

- `dato-utils.ts`: Fullstendig migrering til date-fns/tz, nye funksjoner `toDate()`, `now()`, `osloDate()`
- `helligdager-utils.ts`: Påskeberegning migrert fra dayjs til date-fns
- `dato-komp.tsx`, `periode-komp.tsx`, `aar-maaned-komp.tsx`: `fromDate`/`toDate`-props fikset
- `hent-svar.ts`: DATOER-svartype fikset (`new Date()` → `toDate()`)
- `sporsmal-utils.ts`, `valider-arbeidsgrad.ts`: Migrert til date-fns, Infinity%-bug fikset
- `listevisning-lenkepanel.tsx`, `fremtidige-soknader-teaser.tsx`: Siste dayjs-brukere i produksjons-UI migrert til `addDays` fra date-fns
- `friskmeldt-til-arbeidsformidling.ts`, `nytt-arbeidsforhold.ts`: Mock-data migrert, strenger sendes direkte til `tilLesbarPeriodeMedArstall`
- `playwright/utils/fixtures.ts`: `page.addInitScript` → `context.addInitScript` (portet fra navikt/spinnsyn-frontend#3181 — sikrer at localStorage-scriptet gjelder alle sider i konteksten ved `test.use({ timezoneId })`)
- `playwright/tidssone-datovisning.spec.ts`: Ny fil med E2E-tester; importerer nå fra fixtures (UU-validering + beforeEach)
- `vitest.config.ts`: `envDir` peker på ikke-eksisterende katalog for å isolere tidssone-sensitive tester fra lokal `.env`

## Tester

- ✅ 61 unit-tester passerer med `TZ=America/New_York`
- ✅ Playwright E2E: DatePicker blokkerer navigering forbi grensedato i NYC og Oslo
- ✅ 27 helligdager-tester verifiserer identisk påskeberegning
- ✅ TypeScript, build og format OK

## Scope

Denne PR-en migrerer alle bug-steder og de siste daglige dayjs-brukerne i produksjonskode. Resterende dayjs-bruk (`dayjsToDate` i `mapping.ts` og `rs-soknadmetadata.ts`, samt `parseDate`-alias) er teknisk gjeld uten tidssone-risiko og fjernes i oppfølgende PR: **refactor: fjern dayjs-avhengighet**.