### PR TITLE
Oppdatering tekst om inntektsmelding på kvittering

### DIFF
--- a/playwright/0_arbeidstaker_100.spec.ts
+++ b/playwright/0_arbeidstaker_100.spec.ts
@@ -290,7 +290,10 @@ test.describe('Tester arbeidstakersøknad - 100%', () => {
 
             const kvittering = page.locator('[data-cy="kvittering"]')
             await expect(kvittering).toContainText('Hva skjer videre?')
-            await expect(kvittering).toContainText('Før NAV kan behandle søknaden')
+            await expect(kvittering).toContainText('Nav ber arbeidsgiveren din om inntektsmelding')
+            await expect(kvittering).toContainText(
+                'For å behandle søknaden trenger vi en inntektsmelding fra arbeidsgiveren din',
+            )
             await expect(kvittering).toContainText('NAV behandler søknaden')
             await expect(kvittering).toContainText('Når blir pengene utbetalt')
             await validerAxeUtilityWrapper(page, test.info())

--- a/playwright/0_behandlingsdager.spec.ts
+++ b/playwright/0_behandlingsdager.spec.ts
@@ -1,10 +1,10 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, Page } from '@playwright/test'
 
 import { behandlingsdager } from '../src/data/mock/data/soknad/behandlingsdager'
 
 import { validerAxeUtilityWrapper } from './uuvalidering'
 
-async function checkViStolerPaDeg(page, gaVidere = true) {
+async function checkViStolerPaDeg(page: Page, gaVidere = true) {
     await page
         .getByRole('checkbox', {
             name: /Jeg bekrefter at jeg vil svare så riktig som jeg kan./i,
@@ -15,7 +15,7 @@ async function checkViStolerPaDeg(page, gaVidere = true) {
     }
 }
 
-async function klikkGaVidere(page, forventFeil = false, skipFocusCheck = false) {
+async function klikkGaVidere(page: Page, forventFeil = false, skipFocusCheck = false) {
     const currentUrl = page.url()
     const currentPathParam = parseInt(currentUrl.split('/').pop()!, 10)
 
@@ -33,7 +33,7 @@ async function klikkGaVidere(page, forventFeil = false, skipFocusCheck = false) 
     }
 }
 
-async function klikkTilbake(page) {
+async function klikkTilbake(page: Page) {
     const currentUrl = page.url()
     const currentPathParam = parseInt(currentUrl.split('/').pop()!, 10)
 
@@ -48,7 +48,7 @@ async function klikkTilbake(page) {
     await expect(page.locator('#maincontent')).toBeFocused()
 }
 
-async function sjekkIntroside(page) {
+async function sjekkIntroside(page: Page) {
     await expect(
         page.getByText(
             'Her kan du søke om sykepenger mens du er sykmeldt. ' +
@@ -87,12 +87,12 @@ async function sjekkIntroside(page) {
     ).toHaveAttribute('href', 'https://www.nav.no/endringer')
 }
 
-async function svarNeiHovedsporsmal(page) {
+async function svarNeiHovedsporsmal(page: Page) {
     await page.getByRole('radio', { name: 'Nei' }).first().check()
     await expect(page.getByRole('radio', { name: 'Nei' }).first()).toBeChecked()
 }
 
-async function sporsmalOgSvar(page, sporsmal: string, svar: string) {
+async function sporsmalOgSvar(page: Page, sporsmal: string, svar: string) {
     const question = page.getByText(sporsmal)
     await expect(question).toBeVisible()
     const answer = question.locator('xpath=following-sibling::*').first()
@@ -213,7 +213,10 @@ test.describe('Tester behandlingsdagersøknad', () => {
             await expect(page).toHaveURL(new RegExp('/kvittering/'))
             const kvittering = page.locator('[data-cy="kvittering"]')
             await expect(kvittering).toContainText('Hva skjer videre?')
-            await expect(kvittering).toContainText('Før NAV kan behandle søknaden')
+            await expect(kvittering).toContainText('Nav ber arbeidsgiveren din om inntektsmelding')
+            await expect(kvittering).toContainText(
+                'For å behandle søknaden trenger vi en inntektsmelding fra arbeidsgiveren din',
+            )
             await expect(kvittering).toContainText('NAV behandler søknaden')
             await expect(kvittering).toContainText('Når blir pengene utbetalt')
             await validerAxeUtilityWrapper(page, test.info())

--- a/playwright/0_gammel_oppsumering.spec.ts
+++ b/playwright/0_gammel_oppsumering.spec.ts
@@ -264,7 +264,10 @@ test.describe('Sjekker at søknader med gammel oppsummering ser ok ut', () => {
 
             const kvittering = page.locator('[data-cy="kvittering"]')
             await expect(kvittering).toContainText('Hva skjer videre?')
-            await expect(kvittering).toContainText('Før NAV kan behandle søknaden')
+            await expect(kvittering).toContainText('Nav ber arbeidsgiveren din om inntektsmelding')
+            await expect(kvittering).toContainText(
+                'For å behandle søknaden trenger vi en inntektsmelding fra arbeidsgiveren din',
+            )
             await expect(kvittering).toContainText('NAV behandler søknaden')
             await expect(kvittering).toContainText('Når blir pengene utbetalt')
 

--- a/playwright/3_veldig_lang_soknad.spec.ts
+++ b/playwright/3_veldig_lang_soknad.spec.ts
@@ -544,7 +544,8 @@ test.describe('Tester støtte for gamle spørsmål', () => {
         await test.step('Kvittering', async () => {
             await harSynligTittel(page, 'Søknaden er sendt', 2)
             await harSynligTekst(page, 'Hva skjer videre?')
-            await harSynligTekst(page, 'Før NAV kan behandle søknaden')
+            await harSynligTekst(page, 'Nav ber arbeidsgiveren din om inntektsmelding')
+            await harSynligTekst(page, 'For å behandle søknaden trenger vi en inntektsmelding fra arbeidsgiveren din')
             await harSynligTekst(page, 'NAV behandler søknaden')
             await harSynligTekst(page, 'Når blir pengene utbetalt')
         })

--- a/playwright/kvittering.int.spec.ts
+++ b/playwright/kvittering.int.spec.ts
@@ -182,8 +182,9 @@ test.describe('Kvittering integrasjon', () => {
             await expect(page.locator('[data-cy="sendt-arbeidsgiver"]')).toBeVisible()
             const panel = page.locator('[data-cy="kvittering"]')
             await expect(panel).toContainText('Hva skjer videre?')
-            await expect(panel).toContainText('Før NAV kan behandle søknaden')
-            await expect(panel).toContainText('Når sykefraværet ditt er lengre enn 16 kalenderdager')
+            await expect(panel).toContainText(
+                'For å behandle søknaden trenger vi en inntektsmelding fra arbeidsgiveren din',
+            )
             await expect(panel).toContainText('NAV behandler søknaden')
             await expect(panel).toContainText('Når blir pengene utbetalt')
             await expect(page.getByRole('button', { name: 'Jeg vil endre svarene i søknaden' })).toBeVisible()
@@ -203,8 +204,10 @@ test.describe('Kvittering integrasjon', () => {
             )
             const panel = page.locator('[data-cy="kvittering"]')
             await expect(panel).toContainText('Hva skjer videre?')
-            await expect(panel).toContainText('Før NAV kan behandle søknaden')
-            await expect(panel).toContainText('Når sykefraværet ditt er lengre enn 16 kalenderdager')
+            await expect(panel).toContainText('Nav ber arbeidsgiveren din om inntektsmelding')
+            await expect(panel).toContainText(
+                'For å behandle søknaden trenger vi en inntektsmelding fra arbeidsgiveren din',
+            )
             await expect(panel).toContainText('NAV behandler søknaden')
             await expect(panel).toContainText('Når blir pengene utbetalt')
             await expect(page.getByRole('button', { name: 'Jeg vil endre svarene i søknaden' })).toBeVisible()
@@ -224,8 +227,10 @@ test.describe('Kvittering integrasjon', () => {
             )
             const panel = page.locator('[data-cy="kvittering"]')
             await expect(panel).toContainText('Hva skjer videre?')
-            await expect(panel).toContainText('Før NAV kan behandle søknaden')
-            await expect(panel).toContainText('Når sykefraværet ditt er lengre enn 16 kalenderdager')
+            await expect(panel).toContainText('Nav ber arbeidsgiveren din om inntektsmelding')
+            await expect(panel).toContainText(
+                'For å behandle søknaden trenger vi en inntektsmelding fra arbeidsgiveren din',
+            )
             await expect(panel).toContainText('NAV behandler søknaden')
             await expect(panel).toContainText('Når blir pengene utbetalt')
             await expect(page.getByRole('button', { name: 'Jeg vil endre svarene i søknaden' })).toBeVisible()
@@ -269,7 +274,10 @@ test.describe('Kvittering integrasjon', () => {
             )
             const panel = page.locator('[data-cy="kvittering"]')
             await expect(panel).toContainText('Hva skjer videre?')
-            await expect(panel).toContainText('Før NAV kan behandle søknaden')
+            await expect(panel).toContainText('Nav ber arbeidsgiveren din om inntektsmelding')
+            await expect(panel).toContainText(
+                'For å behandle søknaden trenger vi en inntektsmelding fra arbeidsgiveren din',
+            )
             await expect(panel).toContainText('NAV behandler søknaden')
             await expect(panel).toContainText('Når blir pengene utbetalt')
             await expect(page.getByRole('button', { name: 'Jeg vil endre svarene i søknaden' })).toBeVisible()

--- a/src/components/kvittering/arbeidstaker.tsx
+++ b/src/components/kvittering/arbeidstaker.tsx
@@ -93,11 +93,7 @@ const Arbeidstaker = () => {
             case 'inntil16dager':
                 return <Inntil16dager />
             case 'over16dager':
-                return (
-                    <Over16dager
-                        erGradertReisetilskudd={valgtSoknad?.soknadstype === RSSoknadstype.GRADERT_REISETILSKUDD}
-                    />
-                )
+                return <Over16dager />
             case 'utenOpphold':
                 return <PerioderUtenOpphold />
             case 'medOpphold':

--- a/src/components/kvittering/innhold/arbeidstaker/over16dager.tsx
+++ b/src/components/kvittering/innhold/arbeidstaker/over16dager.tsx
@@ -1,51 +1,26 @@
-import { BodyLong, BodyShort, Label } from '@navikt/ds-react'
+import { BodyShort, Label } from '@navikt/ds-react'
 import React from 'react'
 
 import { tekst } from '../../../../utils/tekster'
 import Kontonummer from '../../kontonummer/kontonummer'
 import { LenkeMedIkon } from '../../../lenke-med-ikon/LenkeMedIkon'
-import { KvitteringTekster } from '../../kvittering-tekster'
-import { Begrepsforklarer, BegrepsforklarerModal } from '../../../begrepsforklarer/begrepsforklarer'
 
 import UtbetalingAvPenger from './gjentagende-segmenter/UtbetalingAvPenger'
 
-interface gradertReisetilskuddProps {
-    erGradertReisetilskudd: boolean
-}
-
-const Over16dager = ({ erGradertReisetilskudd }: gradertReisetilskuddProps) => {
-    const [sekstenDagerOpen, set16dagerOpen] = React.useState(false)
-    const [inntektsmeldingOpen, setInntektsmeldingOpen] = React.useState(false)
-
-    const begrepsForklaringInntektsmelding = (
-        <Begrepsforklarer inlinetekst="inntektsmelding" setOpen={setInntektsmeldingOpen} />
-    )
-    const begrepsForklaring16Kalenderdager = (
-        <Begrepsforklarer inlinetekst="16 kalenderdager" setOpen={set16dagerOpen} />
-    )
-
+const Over16dager = () => {
     return (
         <>
             <div className="mt-4">
                 <div>
                     <Label as="h2" spacing>
-                        {KvitteringTekster['kvittering.for.nav.behandler']}
+                        Nav ber arbeidsgiveren din om inntektsmelding
                     </Label>
-                    {erGradertReisetilskudd ? (
-                        <BodyShort>
-                            Når sykefraværet ditt er lengre enn {begrepsForklaring16Kalenderdager}, betyr det at du får
-                            sykepenger og reisetilskudd utbetalt av NAV. Noen arbeidsplasser fortsetter å utbetale
-                            sykepenger og reisetilskudd fra dag 17, men da får de penger tilbake fra NAV senere.
-                            Arbeidsgiveren din må derfor sende oss {begrepsForklaringInntektsmelding} så fort som mulig.
-                        </BodyShort>
-                    ) : (
-                        <BodyShort>
-                            Når sykefraværet ditt er lengre enn {begrepsForklaring16Kalenderdager}, betyr det at du får
-                            sykepenger utbetalt av NAV. Noen arbeidsplasser fortsetter å utbetale sykepenger fra dag 17,
-                            men da får de penger tilbake fra NAV senere. Arbeidsgiveren din må derfor sende oss{' '}
-                            {begrepsForklaringInntektsmelding} så fort som mulig.
-                        </BodyShort>
-                    )}
+                    <BodyShort>
+                        For å behandle søknaden trenger vi en inntektsmelding fra arbeidsgiveren din. Inntektsmeldingen
+                        inneholder blant annet opplysninger om inntekten din, når du var borte fra jobb og om
+                        arbeidsgiver betaler lønn mens du er syk. Nav bruker opplysningene til å beregne hvor mye
+                        sykepenger du kan få.
+                    </BodyShort>
                 </div>
 
                 <div className="mt-8">
@@ -59,30 +34,9 @@ const Over16dager = ({ erGradertReisetilskudd }: gradertReisetilskuddProps) => {
                     />
                     .
                 </div>
-
                 <UtbetalingAvPenger />
-
                 <Kontonummer />
             </div>
-            <BegrepsforklarerModal
-                tittel={tekst('kvittering.hva-er-inntektsmelding')}
-                open={inntektsmeldingOpen}
-                setOpen={setInntektsmeldingOpen}
-            >
-                <BodyLong>{tekst('kvittering.arbeidstaker.over16.inntektsmelding.brodtekst')}</BodyLong>
-            </BegrepsforklarerModal>
-            <BegrepsforklarerModal
-                tittel={tekst('kvittering.arbeidstaker.hvorfor-skille-ved-16-dager')}
-                open={sekstenDagerOpen}
-                setOpen={set16dagerOpen}
-            >
-                {erGradertReisetilskudd ? (
-                    <BodyLong>{tekst('kvittering.arbeidsgiveren-skal-betale-gradertreisetilskudd')}</BodyLong>
-                ) : (
-                    <BodyLong>{tekst('kvittering.arbeidsgiveren-skal-betale')}</BodyLong>
-                )}
-                <BodyLong>{tekst('kvittering.arbeidstaker.over16.inntektsmelding.brodtekst')}</BodyLong>
-            </BegrepsforklarerModal>
         </>
     )
 }

--- a/src/components/kvittering/kvittering-tekster.ts
+++ b/src/components/kvittering/kvittering-tekster.ts
@@ -29,8 +29,9 @@ export const KvitteringTekster = {
     'kvittering.viktig-for-arbeidstaker': 'Viktig for arbeidstaker',
     'kvittering.soker-du-etter':
         'Søker du etter arbeidsgiverperioden må arbeidsgiveren din sende inn inntekts-melding så fort som mulig. Er du usikker på om den er sendt, bør du forhøre deg med arbeidsgiveren din.',
+
     'kvittering.hva-er-arbeidsgiverperioden': 'Hva er arbeidsgiverperioden?',
-    'kvittering.hva-er-inntektsmelding': 'Hva er en inntektsmelding?',
+
     'kvittering.viktig-for-selvstendige': 'Viktig for selvstendige næringsdrivende og frilansere',
     'kvittering.for-at-nav.1': 'For at NAV skal kunne behandle søknaden må du',
     'kvittering.for-at-nav.2': 'sende inn skjema om inntekts-opplysninger',
@@ -39,10 +40,6 @@ export const KvitteringTekster = {
     'kvittering.for-at-nav.3':
         '. Du skal kunne fylle ut og sende inn dette skjemaet én gang. Hvis du sender inn nye sykepengekrav (forlengelser), skal du ikke fylle ut skjemaet.',
 
-    'kvittering.arbeidsgiveren-skal-betale':
-        'Arbeidsgiveren skal betale sykepenger i en periode på opptil 16 kalenderdager, også kalt arbeidsgiverperioden. NAV overtar sykepengeutbetalingen fra og med 17. kalenderdag.',
-    'kvittering.arbeidsgiveren-skal-betale-gradertreisetilskudd':
-        'Arbeidsgiveren skal betale sykepenger og reisetilskudd i en periode på opptil 16 kalenderdager, også kalt arbeidsgiverperioden. NAV overtar sykepengeutbetalingen fra og med 17. kalenderdag.',
     'kvittering.digital-inntektsmelding':
         'Digital inntektsmelding sendes fra arbeidsgivers eget lønns- og personalsystem eller fra altinn.no. Meldingen inneholder inntektsopplysninger og annen informasjon NAV må ha for å behandle søknaden arbeidstaker har sendt.',
     'kvittering.for.nav.behandler': 'Før NAV kan behandle søknaden',
@@ -60,15 +57,12 @@ export const KvitteringTekster = {
         'Etter at sykefraværsperioden er over, søker du om sykepenger på vanlig måte. Du får en melding fra NAV når søknaden er klar til å fylles ut.',
 
     'kvittering.arbeidstaker.tittel': 'Du får sykepengene fra arbeidsgiveren din',
-    'kvittering.arbeidstaker.hvorfor-skille-ved-16-dager': 'Hvorfor går det et skille ved 16 dager?',
     'kvittering.arbeidstaker.saksbehandlingstid':
         'Saksbehandlingstiden regnes fra Nav har mottatt all nødvendig dokumentasjon.',
     'kvittering.arbeidstaker.saksbehandlingstid.lenke': 'Sjekk de oppdaterte saksbehandlingstidene',
     'kvittering.arbeidstaker.saksbehandlingstid.lenke.url': 'https://www.nav.no/saksbehandlingstider#sykepenger',
     'kvittering.arbeidstaker.brodtekst':
         'Arbeidsgiveren din betaler de første 16 kalenderdagene av sykefraværet. Noen arbeidsplasser fortsetter å utbetale sykepenger fra dag 17, men da får de penger tilbake fra NAV.',
-    'kvittering.arbeidstaker.over16.inntektsmelding.brodtekst':
-        'Arbeidsplassen din sender inntektsopplysninger og annen informasjon som NAV trenger for å behandle søkaden din. Inntektsmeldingen sendes digitalt fra arbeidsplassens lønns- og personalsystem eller fra Altinn.no.',
     'kvittering.arbeidstaker.over16.utbetaling':
         'Du får vanligvis utbetalt sykepengene enten innen den 25. i måneden, eller innen fem dager etter at vi har sendt deg svar på søknaden din. Hvis søknaden din gjelder dager i to ulike kalendermåneder, kan utbetalingen bli delt i to. <a href="https://www.nav.no/utbetalingsdatoer#sykepenger" target="_blank" rel="noreferrer">Les mer om når du kan forvente å få pengene.</a>',
     'kvittering.arbeidstaker.over16.utbetaling-arbeidsgiver':


### PR DESCRIPTION
- Bruker én felles tekst med informasjon om inntektsmelding på kvittering
i stedet for to forskjellige tekster for vanlige og gradert.
- Fjernet modaler med informasjon da den er bakt inn i teksten.
