### PR TITLE
Fjern harRedusertArbeidsgiverperiode fra mock-data

### DIFF
--- a/src/data/mock/data/personas/fisker.ts
+++ b/src/data/mock/data/personas/fisker.ts
@@ -529,7 +529,6 @@ const sykmelding = new Sykmelding({
     navnFastlege: null,
     egenmeldt: false,
     papirsykmelding: false,
-    harRedusertArbeidsgiverperiode: false,
     merknader: null,
     rulesetVersion: '3',
     utenlandskSykmelding: null,

--- a/src/data/mock/data/sykmeldinger.ts
+++ b/src/data/mock/data/sykmeldinger.ts
@@ -138,7 +138,6 @@ export const arbeidstaker100Syk = new Sykmelding({
     navnFastlege: 'Victor Frankenstein',
     egenmeldt: false,
     papirsykmelding: false,
-    harRedusertArbeidsgiverperiode: false,
     merknader: null,
 })
 export const arbeidstaker50Syk = new Sykmelding({
@@ -269,7 +268,6 @@ export const arbeidstaker50Syk = new Sykmelding({
     navnFastlege: 'Victor Frankenstein',
     egenmeldt: false,
     papirsykmelding: false,
-    harRedusertArbeidsgiverperiode: false,
     merknader: null,
 })
 export const arbeidsledig100Syk = new Sykmelding({
@@ -402,7 +400,6 @@ export const arbeidsledig100Syk = new Sykmelding({
     navnFastlege: 'Victor Frankenstein',
     egenmeldt: false,
     papirsykmelding: false,
-    harRedusertArbeidsgiverperiode: false,
     merknader: null,
 })
 export const frilanser100Syk = new Sykmelding({
@@ -559,7 +556,6 @@ export const frilanser100Syk = new Sykmelding({
     navnFastlege: 'Victor Frankenstein',
     egenmeldt: false,
     papirsykmelding: false,
-    harRedusertArbeidsgiverperiode: false,
     merknader: null,
 })
 export const naringsdrivende100syk = jsonDeepCopy(frilanser100Syk)
@@ -691,7 +687,6 @@ export const arbeidstakerBehandlingsdagSyk = new Sykmelding({
     navnFastlege: 'Victor Frankenstein',
     egenmeldt: false,
     papirsykmelding: false,
-    harRedusertArbeidsgiverperiode: false,
     merknader: null,
 })
 export const arbeidstakerReisetilskuddSyk = new Sykmelding({
@@ -819,7 +814,6 @@ export const arbeidstakerReisetilskuddSyk = new Sykmelding({
     navnFastlege: 'Victor Frankenstein',
     egenmeldt: false,
     papirsykmelding: false,
-    harRedusertArbeidsgiverperiode: false,
     merknader: null,
 })
 
@@ -1112,7 +1106,6 @@ export const gradertReisetilskuddSm = new Sykmelding({
     navnFastlege: 'Victor Frankenstein',
     egenmeldt: false,
     papirsykmelding: false,
-    harRedusertArbeidsgiverperiode: false,
     merknader: null,
 })
 
@@ -1226,7 +1219,6 @@ export const sykmeldingMedEgenmeldingsdager = new Sykmelding({
     navnFastlege: null,
     egenmeldt: false,
     papirsykmelding: false,
-    harRedusertArbeidsgiverperiode: false,
     merknader: null,
     rulesetVersion: '3',
     utenlandskSykmelding: null,

--- a/src/data/mock/data/testadataGeneratorFunksjoner.ts
+++ b/src/data/mock/data/testadataGeneratorFunksjoner.ts
@@ -105,7 +105,6 @@ export function skapSykmelding(opts: { fom: string; tom: string; hovedjobb: stri
         navnFastlege: 'Victor Frankenstein',
         egenmeldt: false,
         papirsykmelding: false,
-        harRedusertArbeidsgiverperiode: false,
         merknader: null,
         utdypendeOpplysninger: {
             '6.2': {


### PR DESCRIPTION
Fjerner COVID-era feltet `harRedusertArbeidsgiverperiode` fra mock/testdata. Feltet returnerer alltid `false` (koronaregler utløp juli 2022) og er fjernet fra API-et i flex-sykmeldinger-backend#584.

Relatert:
- navikt/flex-sykmeldinger-backend#584