### PR TITLE
Trekk ut SoknadMetadata til egen komponent

### DIFF
--- a/playwright/0_arbeidstaker_100.spec.ts
+++ b/playwright/0_arbeidstaker_100.spec.ts
@@ -34,6 +34,9 @@ test.describe('Tester arbeidstakersøknad - 100%', () => {
             await expect(page.getByRole('heading', { name: 'Før du søker' })).toBeVisible()
             await expect(page).toHaveURL(new RegExp(`.*${soknadId}\\/1`))
 
+            await expect(page.getByText('Sykmeldt fra: Posten Norge AS, Bærum')).toBeVisible()
+            await expect(page.getByText('Periode: 1. – 24. april 2020 (100%)')).toBeVisible()
+
             await sjekkIntroside(page)
 
             await expect(

--- a/playwright/0_arbeidstaker_50.spec.ts
+++ b/playwright/0_arbeidstaker_50.spec.ts
@@ -48,6 +48,11 @@ test.describe('Tester arbeidstakersøknad - gradert 50%', () => {
 
             await expect(page).toHaveURL(new RegExp(`.*${soknadId}\/1`))
 
+            await expect(page.getByText('Sykmeldt fra: Posten Norge AS, Bærum')).toBeVisible()
+            await expect(
+                page.getByText('Perioder: 1. – 24. april 2020 (50%), 25. april – 10. mai 2020 (100%)'),
+            ).toBeVisible()
+
             await page.getByLabel('Jeg bekrefter at jeg vil svare så riktig som jeg kan.').check()
 
             await expect(page.getByRole('button', { name: 'Start søknad' })).toBeVisible()

--- a/playwright/tidssone-datovisning.spec.ts
+++ b/playwright/tidssone-datovisning.spec.ts
@@ -56,7 +56,9 @@ test.describe('Tidssone: periodevisning', () => {
             await datoInput.fill('01.04.2020')
             await datoInput.blur()
 
-            await expect(page.getByText('1. – 24. april 2020', { exact: false })).toBeVisible()
+            await expect(
+                page.getByText('Svaret ditt betyr at du har vært i fullt arbeid fra 1. – 24. april 2020'),
+            ).toBeVisible()
         })
     })
 

--- a/src/components/soknad/soknad-metadata.tsx
+++ b/src/components/soknad/soknad-metadata.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { BodyShort } from '@navikt/ds-react'
+
+import { Soknad } from '../../types/types'
+import { tilLesbarPeriodeMedArstall } from '../../utils/dato-utils'
+
+export const SoknadMetadata = ({ soknad }: { soknad: Soknad }) => {
+    const metadataTekst = (soknad: Soknad): string => {
+        if (soknad.arbeidsgiver?.navn) {
+            return 'Sykmeldt fra: ' + soknad.arbeidsgiver.navn
+        }
+        return `Sykmeldt som: ${soknad.arbeidssituasjon}`
+    }
+
+    return (
+        <>
+            {soknad.arbeidssituasjon && <BodyShort size="small">{metadataTekst(soknad)}</BodyShort>}
+            {soknad.soknadPerioder && soknad.soknadPerioder.length > 0 && (
+                <BodyShort size="small" spacing>
+                    {soknad.soknadPerioder.length > 1 ? 'Perioder: ' : 'Periode: '}
+                    {soknad.soknadPerioder
+                        .map(
+                            (periode) =>
+                                `${tilLesbarPeriodeMedArstall(periode.fom, periode.tom)}${periode.grad > 0 ? ` (${periode.grad}%)` : ''}`,
+                        )
+                        .join(', ')}
+                </BodyShort>
+            )}
+        </>
+    )
+}

--- a/src/components/soknad/soknaden.tsx
+++ b/src/components/soknad/soknaden.tsx
@@ -25,6 +25,7 @@ import { FlexjarSporsmalV2 } from '../flexjar/flexjar-sporsmal-v2'
 import { urlTilSoknad } from './soknad-link'
 import { SporsmalTittel } from './sporsmal-tittel'
 import { SoknadHeader } from './soknad-header'
+import { SoknadMetadata } from './soknad-metadata'
 
 const sporsmalMedNyFlexjar = [
     'NARINGSDRIVENDE_OPPRETTHOLDT_INNTEKT',
@@ -119,6 +120,7 @@ export const Soknaden = () => {
             {!erForstesiden && <Tilbake variant="liten" />}
 
             <SoknadHeader overskrivTittel={erSistesiden ? 'Oppsummering' : undefined} />
+            {valgtSoknad && <SoknadMetadata soknad={valgtSoknad} />}
 
             {!erForstesiden && <Fremdriftsbar />}
             {erForstesiden && <Introside></Introside>}

--- a/src/data/mock/data/soknad/arbeidstaker-gradert.ts
+++ b/src/data/mock/data/soknad/arbeidstaker-gradert.ts
@@ -48,6 +48,12 @@ export const arbeidstakerGradert: RSSoknad = {
             grad: 50,
             sykmeldingstype: 'GRADERT',
         },
+        {
+            fom: '2020-04-25',
+            tom: '2020-05-10',
+            grad: 100,
+            sykmeldingstype: 'AKTIVITET_IKKE_MULIG',
+        },
     ],
     sporsmal: [
         {


### PR DESCRIPTION
Viser arbeidsgiver/arbeidssituasjon og perioder med grad under søknadsoverskriften. Ny komponent `SoknadMetadata` erstatter inline-logikk i `soknaden.tsx`.

Legger til en ekstra periode i gradert testdata og E2E-assertions for metadata i arbeidstaker 100% og gradert 50%.