### PR TITLE
Trekk ut svarJaNeiStor-hjelpefunksjon i Playwright

### DIFF
--- a/playwright/0_arbeidsledig_100.spec.ts
+++ b/playwright/0_arbeidsledig_100.spec.ts
@@ -7,7 +7,8 @@ import {
     setPeriodeFraTil,
     sjekkIntroside,
     sporsmalOgSvar,
-    svarJaNeiStor,
+    svarJaHovedsporsmal,
+    svarNeiHovedsporsmal,
 } from './utils/utilities'
 import { validerAxeUtilityWrapper } from './uuvalidering'
 
@@ -45,7 +46,7 @@ test.describe('Tester arbeidsledigsøknad', () => {
             await expect(page).toHaveURL(new RegExp(`${arbeidsledig.id}/2`))
 
             // Test spørsmål: Velg 'NEI' på hovedspørsmål
-            await svarJaNeiStor(page, 'NEI')
+            await svarNeiHovedsporsmal(page)
             await expect(page.getByText('Fra hvilken dato trengte du ikke lenger sykmeldingen?')).toBeVisible()
 
             // Velg dato i kalender
@@ -66,7 +67,7 @@ test.describe('Tester arbeidsledigsøknad', () => {
             ).toBeVisible()
 
             // Velg 'JA' på hovedspørsmål
-            await svarJaNeiStor(page, 'JA')
+            await svarJaHovedsporsmal(page)
 
             await validerAxeUtilityWrapper(page, test.info())
 
@@ -107,7 +108,7 @@ test.describe('Tester arbeidsledigsøknad', () => {
             ])
 
             // Velg 'JA' på hovedspørsmål
-            await svarJaNeiStor(page, 'JA')
+            await svarJaHovedsporsmal(page)
 
             // Underspørsmål 1: Sett periode
             await expect(page.getByText('Når var du utenfor EU/EØS?')).toBeVisible()

--- a/playwright/0_arbeidsledig_100.spec.ts
+++ b/playwright/0_arbeidsledig_100.spec.ts
@@ -7,6 +7,7 @@ import {
     setPeriodeFraTil,
     sjekkIntroside,
     sporsmalOgSvar,
+    svarJaNeiStor,
 } from './utils/utilities'
 import { validerAxeUtilityWrapper } from './uuvalidering'
 
@@ -44,7 +45,7 @@ test.describe('Tester arbeidsledigsøknad', () => {
             await expect(page).toHaveURL(new RegExp(`${arbeidsledig.id}/2`))
 
             // Test spørsmål: Velg 'NEI' på hovedspørsmål
-            await page.locator('[data-cy="ja-nei-stor"] input[value=NEI]').check() // Velg 'Nei' (tilsvarer Cypress .click() på radio)
+            await svarJaNeiStor(page, 'NEI')
             await expect(page.getByText('Fra hvilken dato trengte du ikke lenger sykmeldingen?')).toBeVisible()
 
             // Velg dato i kalender
@@ -65,7 +66,7 @@ test.describe('Tester arbeidsledigsøknad', () => {
             ).toBeVisible()
 
             // Velg 'JA' på hovedspørsmål
-            await page.locator('[data-cy="ja-nei-stor"] input[value=JA]').check()
+            await svarJaNeiStor(page, 'JA')
 
             await validerAxeUtilityWrapper(page, test.info())
 
@@ -106,7 +107,7 @@ test.describe('Tester arbeidsledigsøknad', () => {
             ])
 
             // Velg 'JA' på hovedspørsmål
-            await page.locator('[data-cy="ja-nei-stor"] input[value=JA]').check()
+            await svarJaNeiStor(page, 'JA')
 
             // Underspørsmål 1: Sett periode
             await expect(page.getByText('Når var du utenfor EU/EØS?')).toBeVisible()

--- a/playwright/0_arbeidstaker_100.spec.ts
+++ b/playwright/0_arbeidstaker_100.spec.ts
@@ -12,7 +12,7 @@ import {
     harSoknaderlisteHeading,
     trykkPaSoknadMedId,
     svarFritekst,
-    svarJaNeiStor,
+    svarJaHovedsporsmal,
 } from './utils/utilities'
 import { validerAxeUtilityWrapper } from './uuvalidering'
 
@@ -65,7 +65,7 @@ test.describe('Tester arbeidstakersøknad - 100%', () => {
             await expect(page.locator('.aksel-progress-bar')).toHaveAttribute('aria-valuemax', '7')
             await expect(page.locator('.aksel-progress-bar')).toHaveAttribute('aria-valuetext', '1 av 7')
 
-            await svarJaNeiStor(page, 'JA')
+            await svarJaHovedsporsmal(page)
             await expect(page.getByText('Når begynte du å jobbe igjen?')).toBeVisible()
 
             await page.locator('.aksel-date__field-button').click()
@@ -93,7 +93,7 @@ test.describe('Tester arbeidstakersøknad - 100%', () => {
                 'Du kan dra på ferie mens du er sykmeldt, men du får ikke utbetalt sykepenger når du har ferie',
             ])
 
-            await svarJaNeiStor(page, 'JA')
+            await svarJaHovedsporsmal(page)
             await expect(page.getByText('Når tok du ut feriedager?')).toBeVisible()
 
             await setPeriodeFraTil(page, 16, 23)
@@ -114,7 +114,7 @@ test.describe('Tester arbeidstakersøknad - 100%', () => {
                 page.getByText('Permisjon er dager du var borte fra jobb av andre grunner enn sykdom'),
             ).toBeVisible()
 
-            await svarJaNeiStor(page, 'JA')
+            await svarJaHovedsporsmal(page)
             await expect(page.getByText('Når tok du permisjon?')).toBeVisible()
 
             await setPeriodeFraTil(page, 14, 22)
@@ -137,7 +137,7 @@ test.describe('Tester arbeidstakersøknad - 100%', () => {
                 'Dersom du har gjort færre arbeidsoppgaver enn vanlig, men brukt lengre tid på dem',
             ])
 
-            await svarJaNeiStor(page, 'JA')
+            await svarJaHovedsporsmal(page)
 
             await expect(page.getByText('Oppgi arbeidsmengde i timer eller prosent')).toBeVisible()
 
@@ -183,7 +183,7 @@ test.describe('Tester arbeidstakersøknad - 100%', () => {
                 'Jobbet mer i en annen jobb etter at du ble sykmeldt',
             ])
 
-            await svarJaNeiStor(page, 'JA')
+            await svarJaHovedsporsmal(page)
 
             const ansattAndreSteder = page
                 .getByText('Velg inntektskildene som passer for deg:')
@@ -216,7 +216,7 @@ test.describe('Tester arbeidstakersøknad - 100%', () => {
                 'Da oppretter vi en egen søknad som du må sende inn',
             ])
 
-            await svarJaNeiStor(page, 'JA')
+            await svarJaHovedsporsmal(page)
             await expect(page.getByText('Når var du utenfor EU/EØS?')).toBeVisible()
 
             await setPeriodeFraTil(page, 14, 22)

--- a/playwright/0_arbeidstaker_100.spec.ts
+++ b/playwright/0_arbeidstaker_100.spec.ts
@@ -12,6 +12,7 @@ import {
     harSoknaderlisteHeading,
     trykkPaSoknadMedId,
     svarFritekst,
+    svarJaNeiStor,
 } from './utils/utilities'
 import { validerAxeUtilityWrapper } from './uuvalidering'
 
@@ -64,7 +65,7 @@ test.describe('Tester arbeidstakersøknad - 100%', () => {
             await expect(page.locator('.aksel-progress-bar')).toHaveAttribute('aria-valuemax', '7')
             await expect(page.locator('.aksel-progress-bar')).toHaveAttribute('aria-valuetext', '1 av 7')
 
-            await page.locator('[data-cy="ja-nei-stor"] input[value="JA"]').check()
+            await svarJaNeiStor(page, 'JA')
             await expect(page.getByText('Når begynte du å jobbe igjen?')).toBeVisible()
 
             await page.locator('.aksel-date__field-button').click()
@@ -92,7 +93,7 @@ test.describe('Tester arbeidstakersøknad - 100%', () => {
                 'Du kan dra på ferie mens du er sykmeldt, men du får ikke utbetalt sykepenger når du har ferie',
             ])
 
-            await page.locator('[data-cy="ja-nei-stor"] input[value="JA"]').check()
+            await svarJaNeiStor(page, 'JA')
             await expect(page.getByText('Når tok du ut feriedager?')).toBeVisible()
 
             await setPeriodeFraTil(page, 16, 23)
@@ -113,7 +114,7 @@ test.describe('Tester arbeidstakersøknad - 100%', () => {
                 page.getByText('Permisjon er dager du var borte fra jobb av andre grunner enn sykdom'),
             ).toBeVisible()
 
-            await page.locator('[data-cy="ja-nei-stor"] input[value="JA"]').check()
+            await svarJaNeiStor(page, 'JA')
             await expect(page.getByText('Når tok du permisjon?')).toBeVisible()
 
             await setPeriodeFraTil(page, 14, 22)
@@ -136,7 +137,7 @@ test.describe('Tester arbeidstakersøknad - 100%', () => {
                 'Dersom du har gjort færre arbeidsoppgaver enn vanlig, men brukt lengre tid på dem',
             ])
 
-            await page.locator('[data-cy="ja-nei-stor"] input[value="JA"]').check()
+            await svarJaNeiStor(page, 'JA')
 
             await expect(page.getByText('Oppgi arbeidsmengde i timer eller prosent')).toBeVisible()
 
@@ -182,7 +183,7 @@ test.describe('Tester arbeidstakersøknad - 100%', () => {
                 'Jobbet mer i en annen jobb etter at du ble sykmeldt',
             ])
 
-            await page.locator('[data-cy="ja-nei-stor"] input[value="JA"]').check()
+            await svarJaNeiStor(page, 'JA')
 
             const ansattAndreSteder = page
                 .getByText('Velg inntektskildene som passer for deg:')
@@ -215,7 +216,7 @@ test.describe('Tester arbeidstakersøknad - 100%', () => {
                 'Da oppretter vi en egen søknad som du må sende inn',
             ])
 
-            await page.locator('[data-cy="ja-nei-stor"] input[value="JA"]').check()
+            await svarJaNeiStor(page, 'JA')
             await expect(page.getByText('Når var du utenfor EU/EØS?')).toBeVisible()
 
             await setPeriodeFraTil(page, 14, 22)

--- a/playwright/0_arbeidstaker_50.spec.ts
+++ b/playwright/0_arbeidstaker_50.spec.ts
@@ -2,7 +2,7 @@ import { test, expect, Page } from '@playwright/test'
 
 import { arbeidstakerGradert } from '../src/data/mock/data/soknad/arbeidstaker-gradert'
 
-import { apneReadmore, svarJaNeiStor } from './utils/utilities'
+import { apneReadmore, svarJaHovedsporsmal } from './utils/utilities'
 import { validerAxeUtilityWrapper } from './uuvalidering'
 const fillTextFieldByLabel = async (page: Page, labelText: string, value: string, fallbackSelector?: string) => {
     try {
@@ -66,7 +66,7 @@ test.describe('Tester arbeidstakersøknad - gradert 50%', () => {
 
         await test.step('Søknad TILBAKE_I_ARBEID', async () => {
             await expect(page).toHaveURL(new RegExp(`.*${soknadId}\/2`))
-            await svarJaNeiStor(page, 'JA')
+            await svarJaHovedsporsmal(page)
             await expect(page.locator('text=Når begynte du å jobbe igjen?')).toBeVisible()
             await page.locator('.aksel-date__field-button').click()
             await page.locator('.rdp-day').getByText('20', { exact: true }).click()
@@ -76,7 +76,7 @@ test.describe('Tester arbeidstakersøknad - gradert 50%', () => {
 
         await test.step('Søknad FERIE_V2', async () => {
             await expect(page).toHaveURL(new RegExp(`.*${soknadId}\/3`))
-            await svarJaNeiStor(page, 'JA')
+            await svarJaHovedsporsmal(page)
             await expect(page.locator('text=Når tok du ut feriedager?')).toBeVisible()
             await setPeriodeFraTil(page, 16, 23)
             await validerAxeUtilityWrapper(page, test.info())
@@ -85,7 +85,7 @@ test.describe('Tester arbeidstakersøknad - gradert 50%', () => {
 
         await test.step('Søknad PERMISJON_V2', async () => {
             await expect(page).toHaveURL(new RegExp(`.*${soknadId}\/4`))
-            await svarJaNeiStor(page, 'JA')
+            await svarJaHovedsporsmal(page)
             await expect(page.locator('text=Når tok du permisjon?')).toBeVisible()
             await setPeriodeFraTil(page, 14, 22)
             await validerAxeUtilityWrapper(page, test.info())
@@ -100,7 +100,7 @@ test.describe('Tester arbeidstakersøknad - gradert 50%', () => {
                 'Dersom du har gjort færre arbeidsoppgaver enn vanlig, men brukt lengre tid på dem',
             ])
 
-            await svarJaNeiStor(page, 'JA')
+            await svarJaHovedsporsmal(page)
             await expect(page.locator('text=Antall timer du skrev inn, betyr at du har jobbet')).toBeHidden()
 
             await expect(
@@ -154,7 +154,7 @@ test.describe('Tester arbeidstakersøknad - gradert 50%', () => {
 
         await test.step('Søknad ARBEID_UTENFOR_NORGE', async () => {
             await expect(page).toHaveURL(new RegExp(`.*${soknadId}\/6`))
-            await svarJaNeiStor(page, 'JA')
+            await svarJaHovedsporsmal(page)
             await expect(page.locator('text=Har du arbeidet i utlandet i løpet av de siste 12 månedene?')).toBeVisible()
             await validerAxeUtilityWrapper(page, test.info())
             await page.locator('button').filter({ hasText: 'Gå videre' }).click()
@@ -163,7 +163,7 @@ test.describe('Tester arbeidstakersøknad - gradert 50%', () => {
         await test.step('Søknad ANDRE_INNTEKTSKILDER_V2', async () => {
             await expect(page).toHaveURL(new RegExp(`.*${soknadId}\/7`))
             await expect(page.locator('text=Har du andre inntektskilder enn nevnt over?')).toBeVisible()
-            await svarJaNeiStor(page, 'JA')
+            await svarJaHovedsporsmal(page)
             await expect(
                 page.locator(
                     'text=Velg inntektskildene som passer for deg. Finner du ikke noe som passer for deg, svarer du nei',
@@ -179,7 +179,7 @@ test.describe('Tester arbeidstakersøknad - gradert 50%', () => {
 
         await test.step('Søknad OPPHOLD_UTENFOR_EOS', async () => {
             await expect(page).toHaveURL(new RegExp(`.*${soknadId}\/8`))
-            await svarJaNeiStor(page, 'JA')
+            await svarJaHovedsporsmal(page)
             await expect(page.locator('text=Når var du utenfor EU/EØS?')).toBeVisible()
             await setPeriodeFraTil(page, 14, 22)
             await validerAxeUtilityWrapper(page, test.info())

--- a/playwright/0_arbeidstaker_50.spec.ts
+++ b/playwright/0_arbeidstaker_50.spec.ts
@@ -2,7 +2,7 @@ import { test, expect, Page } from '@playwright/test'
 
 import { arbeidstakerGradert } from '../src/data/mock/data/soknad/arbeidstaker-gradert'
 
-import { apneReadmore } from './utils/utilities'
+import { apneReadmore, svarJaNeiStor } from './utils/utilities'
 import { validerAxeUtilityWrapper } from './uuvalidering'
 const fillTextFieldByLabel = async (page: Page, labelText: string, value: string, fallbackSelector?: string) => {
     try {
@@ -66,7 +66,7 @@ test.describe('Tester arbeidstakersøknad - gradert 50%', () => {
 
         await test.step('Søknad TILBAKE_I_ARBEID', async () => {
             await expect(page).toHaveURL(new RegExp(`.*${soknadId}\/2`))
-            await page.locator('[data-cy="ja-nei-stor"] input[value="JA"]').check()
+            await svarJaNeiStor(page, 'JA')
             await expect(page.locator('text=Når begynte du å jobbe igjen?')).toBeVisible()
             await page.locator('.aksel-date__field-button').click()
             await page.locator('.rdp-day').getByText('20', { exact: true }).click()
@@ -76,7 +76,7 @@ test.describe('Tester arbeidstakersøknad - gradert 50%', () => {
 
         await test.step('Søknad FERIE_V2', async () => {
             await expect(page).toHaveURL(new RegExp(`.*${soknadId}\/3`))
-            await page.locator('[data-cy="ja-nei-stor"] input[value="JA"]').check()
+            await svarJaNeiStor(page, 'JA')
             await expect(page.locator('text=Når tok du ut feriedager?')).toBeVisible()
             await setPeriodeFraTil(page, 16, 23)
             await validerAxeUtilityWrapper(page, test.info())
@@ -85,7 +85,7 @@ test.describe('Tester arbeidstakersøknad - gradert 50%', () => {
 
         await test.step('Søknad PERMISJON_V2', async () => {
             await expect(page).toHaveURL(new RegExp(`.*${soknadId}\/4`))
-            await page.locator('[data-cy="ja-nei-stor"] input[value="JA"]').check()
+            await svarJaNeiStor(page, 'JA')
             await expect(page.locator('text=Når tok du permisjon?')).toBeVisible()
             await setPeriodeFraTil(page, 14, 22)
             await validerAxeUtilityWrapper(page, test.info())
@@ -100,7 +100,7 @@ test.describe('Tester arbeidstakersøknad - gradert 50%', () => {
                 'Dersom du har gjort færre arbeidsoppgaver enn vanlig, men brukt lengre tid på dem',
             ])
 
-            await page.locator('[data-cy="ja-nei-stor"] input[value="JA"]').check()
+            await svarJaNeiStor(page, 'JA')
             await expect(page.locator('text=Antall timer du skrev inn, betyr at du har jobbet')).toBeHidden()
 
             await expect(
@@ -154,7 +154,7 @@ test.describe('Tester arbeidstakersøknad - gradert 50%', () => {
 
         await test.step('Søknad ARBEID_UTENFOR_NORGE', async () => {
             await expect(page).toHaveURL(new RegExp(`.*${soknadId}\/6`))
-            await page.locator('[data-cy="ja-nei-stor"] input[value="JA"]').check()
+            await svarJaNeiStor(page, 'JA')
             await expect(page.locator('text=Har du arbeidet i utlandet i løpet av de siste 12 månedene?')).toBeVisible()
             await validerAxeUtilityWrapper(page, test.info())
             await page.locator('button').filter({ hasText: 'Gå videre' }).click()
@@ -163,7 +163,7 @@ test.describe('Tester arbeidstakersøknad - gradert 50%', () => {
         await test.step('Søknad ANDRE_INNTEKTSKILDER_V2', async () => {
             await expect(page).toHaveURL(new RegExp(`.*${soknadId}\/7`))
             await expect(page.locator('text=Har du andre inntektskilder enn nevnt over?')).toBeVisible()
-            await page.locator('[data-cy="ja-nei-stor"] input[value="JA"]').check()
+            await svarJaNeiStor(page, 'JA')
             await expect(
                 page.locator(
                     'text=Velg inntektskildene som passer for deg. Finner du ikke noe som passer for deg, svarer du nei',
@@ -179,7 +179,7 @@ test.describe('Tester arbeidstakersøknad - gradert 50%', () => {
 
         await test.step('Søknad OPPHOLD_UTENFOR_EOS', async () => {
             await expect(page).toHaveURL(new RegExp(`.*${soknadId}\/8`))
-            await page.locator('[data-cy="ja-nei-stor"] input[value="JA"]').check()
+            await svarJaNeiStor(page, 'JA')
             await expect(page.locator('text=Når var du utenfor EU/EØS?')).toBeVisible()
             await setPeriodeFraTil(page, 14, 22)
             await validerAxeUtilityWrapper(page, test.info())

--- a/playwright/0_behandlingsdager.spec.ts
+++ b/playwright/0_behandlingsdager.spec.ts
@@ -3,6 +3,7 @@ import { test, expect, Page } from '@playwright/test'
 import { behandlingsdager } from '../src/data/mock/data/soknad/behandlingsdager'
 
 import { validerAxeUtilityWrapper } from './uuvalidering'
+import { svarJaNeiStor } from './utils/utilities'
 
 async function checkViStolerPaDeg(page: Page, gaVidere = true) {
     await page
@@ -159,7 +160,7 @@ test.describe('Tester behandlingsdagersøknad', () => {
         await test.step('Søknad ANDRE_INNTEKTSKILDER - steg 4', async () => {
             await expect(page).toHaveURL(new RegExp(`${soknad.id}/4`))
 
-            await page.locator('[data-cy="ja-nei-stor"] input[value=JA]').check()
+            await svarJaNeiStor(page, 'JA')
 
             await expect(page.getByText('Hvilke andre inntektskilder har du?')).toBeVisible()
             await expect(page.locator('.undersporsmal .aksel-checkbox label[for="687382"]')).toHaveText(

--- a/playwright/0_behandlingsdager.spec.ts
+++ b/playwright/0_behandlingsdager.spec.ts
@@ -3,7 +3,7 @@ import { test, expect, Page } from '@playwright/test'
 import { behandlingsdager } from '../src/data/mock/data/soknad/behandlingsdager'
 
 import { validerAxeUtilityWrapper } from './uuvalidering'
-import { svarJaNeiStor } from './utils/utilities'
+import { svarJaHovedsporsmal } from './utils/utilities'
 
 async function checkViStolerPaDeg(page: Page, gaVidere = true) {
     await page
@@ -160,7 +160,7 @@ test.describe('Tester behandlingsdagersøknad', () => {
         await test.step('Søknad ANDRE_INNTEKTSKILDER - steg 4', async () => {
             await expect(page).toHaveURL(new RegExp(`${soknad.id}/4`))
 
-            await svarJaNeiStor(page, 'JA')
+            await svarJaHovedsporsmal(page)
 
             await expect(page.getByText('Hvilke andre inntektskilder har du?')).toBeVisible()
             await expect(page.locator('.undersporsmal .aksel-checkbox label[for="687382"]')).toHaveText(

--- a/playwright/0_gammel_oppsumering.spec.ts
+++ b/playwright/0_gammel_oppsumering.spec.ts
@@ -2,7 +2,13 @@ import { test, expect } from '@playwright/test'
 
 import { arbeidtakerMedGammelOppsummering } from '../src/data/mock/data/soknad/arbeidstaker'
 
-import { setPeriodeFraTil, sporsmalOgSvar, svarJaNeiStor, svarTekstboks, trykkPaSoknadMedId } from './utils/utilities'
+import {
+    setPeriodeFraTil,
+    sporsmalOgSvar,
+    svarJaHovedsporsmal,
+    svarTekstboks,
+    trykkPaSoknadMedId,
+} from './utils/utilities'
 import { validerAxeUtilityWrapper } from './uuvalidering'
 
 test.describe('Sjekker at søknader med gammel oppsummering ser ok ut', () => {
@@ -60,7 +66,7 @@ test.describe('Sjekker at søknader med gammel oppsummering ser ok ut', () => {
             await expect(progressBar).toHaveAttribute('aria-valuetext', '1 av 7')
 
             // Test spørsmål
-            await svarJaNeiStor(page, 'JA')
+            await svarJaHovedsporsmal(page)
             await expect(page.getByText('Når begynte du å jobbe igjen?')).toBeVisible()
             await page.locator('.aksel-date__field-button').click()
             await page.locator('.rdp-day').getByText('20').click()
@@ -80,7 +86,7 @@ test.describe('Sjekker at søknader med gammel oppsummering ser ok ut', () => {
         await test.step('Søknad FERIE_V2', async () => {
             await expect(page).toHaveURL(/\/soknader\/.*\/3/)
 
-            await svarJaNeiStor(page, 'JA')
+            await svarJaHovedsporsmal(page)
             await expect(page.getByText('Når tok du ut feriedager?')).toBeVisible()
 
             await setPeriodeFraTil(page, 16, 23)
@@ -101,7 +107,7 @@ test.describe('Sjekker at søknader med gammel oppsummering ser ok ut', () => {
                 page.getByText('Permisjon er dager du var borte fra jobb av andre grunner enn sykdom'),
             ).toBeVisible()
 
-            await svarJaNeiStor(page, 'JA')
+            await svarJaHovedsporsmal(page)
             await expect(page.getByText('Når tok du permisjon?')).toBeVisible()
 
             await setPeriodeFraTil(page, 14, 22)
@@ -118,7 +124,7 @@ test.describe('Sjekker at søknader med gammel oppsummering ser ok ut', () => {
                     'I perioden 1. - 24. april 2020 var du 100 % sykmeldt fra Posten Norge AS, Bærum. Jobbet du noe hos Posten Norge AS, Bærum i denne perioden?',
                 ),
             ).toBeVisible()
-            await svarJaNeiStor(page, 'JA')
+            await svarJaHovedsporsmal(page)
 
             await expect(page.getByText('Oppgi arbeidsmengde i timer eller prosent')).toBeVisible()
             await page.locator('.undersporsmal input[value=Prosent]').click()
@@ -164,7 +170,7 @@ test.describe('Sjekker at søknader med gammel oppsummering ser ok ut', () => {
 
             await expect(page.getByText('Har du andre inntektskilder enn nevnt over?')).toBeVisible()
 
-            await svarJaNeiStor(page, 'JA')
+            await svarJaHovedsporsmal(page)
 
             const checkboxParent = page.getByText('Velg inntektskildene som passer for deg:').locator('..')
             await checkboxParent.getByText('Ansatt andre steder enn nevnt over').locator('..').click()
@@ -185,7 +191,7 @@ test.describe('Sjekker at søknader med gammel oppsummering ser ok ut', () => {
         await test.step('Søknad OPPHOLD_UTENFOR_EOS', async () => {
             await expect(page).toHaveURL(/\/soknader\/.*\/7/)
 
-            await svarJaNeiStor(page, 'JA')
+            await svarJaHovedsporsmal(page)
             await expect(page.getByText('Når var du utenfor EU/EØS?')).toBeVisible()
 
             await setPeriodeFraTil(page, 14, 22)

--- a/playwright/0_gammel_oppsumering.spec.ts
+++ b/playwright/0_gammel_oppsumering.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 import { arbeidtakerMedGammelOppsummering } from '../src/data/mock/data/soknad/arbeidstaker'
 
-import { setPeriodeFraTil, sporsmalOgSvar, svarTekstboks, trykkPaSoknadMedId } from './utils/utilities'
+import { setPeriodeFraTil, sporsmalOgSvar, svarJaNeiStor, svarTekstboks, trykkPaSoknadMedId } from './utils/utilities'
 import { validerAxeUtilityWrapper } from './uuvalidering'
 
 test.describe('Sjekker at søknader med gammel oppsummering ser ok ut', () => {
@@ -60,7 +60,7 @@ test.describe('Sjekker at søknader med gammel oppsummering ser ok ut', () => {
             await expect(progressBar).toHaveAttribute('aria-valuetext', '1 av 7')
 
             // Test spørsmål
-            await page.locator('[data-cy="ja-nei-stor"] input[value=JA]').check()
+            await svarJaNeiStor(page, 'JA')
             await expect(page.getByText('Når begynte du å jobbe igjen?')).toBeVisible()
             await page.locator('.aksel-date__field-button').click()
             await page.locator('.rdp-day').getByText('20').click()
@@ -80,7 +80,7 @@ test.describe('Sjekker at søknader med gammel oppsummering ser ok ut', () => {
         await test.step('Søknad FERIE_V2', async () => {
             await expect(page).toHaveURL(/\/soknader\/.*\/3/)
 
-            await page.locator('[data-cy="ja-nei-stor"] input[value=JA]').check()
+            await svarJaNeiStor(page, 'JA')
             await expect(page.getByText('Når tok du ut feriedager?')).toBeVisible()
 
             await setPeriodeFraTil(page, 16, 23)
@@ -101,7 +101,7 @@ test.describe('Sjekker at søknader med gammel oppsummering ser ok ut', () => {
                 page.getByText('Permisjon er dager du var borte fra jobb av andre grunner enn sykdom'),
             ).toBeVisible()
 
-            await page.locator('[data-cy="ja-nei-stor"] input[value=JA]').check()
+            await svarJaNeiStor(page, 'JA')
             await expect(page.getByText('Når tok du permisjon?')).toBeVisible()
 
             await setPeriodeFraTil(page, 14, 22)
@@ -118,7 +118,7 @@ test.describe('Sjekker at søknader med gammel oppsummering ser ok ut', () => {
                     'I perioden 1. - 24. april 2020 var du 100 % sykmeldt fra Posten Norge AS, Bærum. Jobbet du noe hos Posten Norge AS, Bærum i denne perioden?',
                 ),
             ).toBeVisible()
-            await page.locator('[data-cy="ja-nei-stor"] input[value=JA]').check()
+            await svarJaNeiStor(page, 'JA')
 
             await expect(page.getByText('Oppgi arbeidsmengde i timer eller prosent')).toBeVisible()
             await page.locator('.undersporsmal input[value=Prosent]').click()
@@ -164,7 +164,7 @@ test.describe('Sjekker at søknader med gammel oppsummering ser ok ut', () => {
 
             await expect(page.getByText('Har du andre inntektskilder enn nevnt over?')).toBeVisible()
 
-            await page.locator('[data-cy="ja-nei-stor"] input[value=JA]').check()
+            await svarJaNeiStor(page, 'JA')
 
             const checkboxParent = page.getByText('Velg inntektskildene som passer for deg:').locator('..')
             await checkboxParent.getByText('Ansatt andre steder enn nevnt over').locator('..').click()
@@ -185,7 +185,7 @@ test.describe('Sjekker at søknader med gammel oppsummering ser ok ut', () => {
         await test.step('Søknad OPPHOLD_UTENFOR_EOS', async () => {
             await expect(page).toHaveURL(/\/soknader\/.*\/7/)
 
-            await page.locator('[data-cy="ja-nei-stor"] input[value=JA]').check()
+            await svarJaNeiStor(page, 'JA')
             await expect(page.getByText('Når var du utenfor EU/EØS?')).toBeVisible()
 
             await setPeriodeFraTil(page, 14, 22)

--- a/playwright/3_julesoknad.spec.ts
+++ b/playwright/3_julesoknad.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 import { julesoknadPerson } from '../src/data/mock/data/personas/personas'
 
-import { checkViStolerPaDeg, klikkGaVidere } from './utils/utilities'
+import { checkViStolerPaDeg, klikkGaVidere, svarJaNeiStor } from './utils/utilities'
 import { validerAxeUtilityWrapper } from './uuvalidering'
 
 test.describe('Julesøkand med informasjon på introside og kvittering', () => {
@@ -31,7 +31,7 @@ test.describe('Julesøkand med informasjon på introside og kvittering', () => {
         await test.step('Søknad TILBAKE_I_ARBEID', async () => {
             await expect(page).toHaveURL(new RegExp(`${soknad.id}/2`))
 
-            await page.locator('[data-cy="ja-nei-stor"] input[value="NEI"]').check()
+            await svarJaNeiStor(page, 'NEI')
             await validerAxeUtilityWrapper(page, test.info())
 
             await klikkGaVidere(page)

--- a/playwright/3_julesoknad.spec.ts
+++ b/playwright/3_julesoknad.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 import { julesoknadPerson } from '../src/data/mock/data/personas/personas'
 
-import { checkViStolerPaDeg, klikkGaVidere, svarJaNeiStor } from './utils/utilities'
+import { checkViStolerPaDeg, klikkGaVidere, svarNeiHovedsporsmal } from './utils/utilities'
 import { validerAxeUtilityWrapper } from './uuvalidering'
 
 test.describe('Julesøkand med informasjon på introside og kvittering', () => {
@@ -31,7 +31,7 @@ test.describe('Julesøkand med informasjon på introside og kvittering', () => {
         await test.step('Søknad TILBAKE_I_ARBEID', async () => {
             await expect(page).toHaveURL(new RegExp(`${soknad.id}/2`))
 
-            await svarJaNeiStor(page, 'NEI')
+            await svarNeiHovedsporsmal(page)
             await validerAxeUtilityWrapper(page, test.info())
 
             await klikkGaVidere(page)

--- a/playwright/3_reisetilskudd.spec.ts
+++ b/playwright/3_reisetilskudd.spec.ts
@@ -11,6 +11,7 @@ import {
     hentFritekst,
     svarRadioClickOption,
     apneReadmore,
+    svarJaNeiStor,
 } from './utils/utilities'
 import { validerAxeUtilityWrapper } from './uuvalidering'
 
@@ -65,7 +66,7 @@ test.describe('Teste førsteside i reisetilskuddsøknaden', () => {
                 'Det kan også være bysykkel og el-sparkesykkel.',
             ])
 
-            await page.locator('[data-cy="ja-nei-stor"] input[value=JA]').check()
+            await svarJaNeiStor(page, 'JA')
             velgCheckbox(page, 'Offentlig transport')
             await expect(
                 page.getByText('Hvor mye betaler du vanligvis i måneden for offentlig transport?'),
@@ -91,7 +92,7 @@ test.describe('Teste førsteside i reisetilskuddsøknaden', () => {
             await expect(page).toHaveURL(new RegExp(`${nyttReisetilskudd.id}/3`))
             await expect(page.locator('[data-cy="sporsmal-tittel"]')).toHaveText('Reise med bil')
 
-            await page.locator('[data-cy="ja-nei-stor"] input[value=JA]').check()
+            await svarJaNeiStor(page, 'JA')
             await expect(page.locator('.undersporsmal > :nth-child(1) > :nth-child(1)')).toHaveText(
                 'Hvilke dager reiste du med bil i perioden 23. desember 2020 - 7. januar 2021?',
             )
@@ -184,7 +185,7 @@ test.describe('Teste førsteside i reisetilskuddsøknaden', () => {
             await expect(page).toHaveURL(new RegExp(`${nyttReisetilskudd.id}/5`))
             await expect(page.locator('[data-cy="sporsmal-tittel"]')).toHaveText('Utbetaling')
 
-            await page.locator('[data-cy="ja-nei-stor"] input[value=JA]').check()
+            await svarJaNeiStor(page, 'JA')
             await validerAxeUtilityWrapper(page, test.info())
             await klikkGaVidere(page)
             steg.value++

--- a/playwright/3_reisetilskudd.spec.ts
+++ b/playwright/3_reisetilskudd.spec.ts
@@ -11,7 +11,7 @@ import {
     hentFritekst,
     svarRadioClickOption,
     apneReadmore,
-    svarJaNeiStor,
+    svarJaHovedsporsmal,
 } from './utils/utilities'
 import { validerAxeUtilityWrapper } from './uuvalidering'
 
@@ -66,7 +66,7 @@ test.describe('Teste førsteside i reisetilskuddsøknaden', () => {
                 'Det kan også være bysykkel og el-sparkesykkel.',
             ])
 
-            await svarJaNeiStor(page, 'JA')
+            await svarJaHovedsporsmal(page)
             velgCheckbox(page, 'Offentlig transport')
             await expect(
                 page.getByText('Hvor mye betaler du vanligvis i måneden for offentlig transport?'),
@@ -92,7 +92,7 @@ test.describe('Teste førsteside i reisetilskuddsøknaden', () => {
             await expect(page).toHaveURL(new RegExp(`${nyttReisetilskudd.id}/3`))
             await expect(page.locator('[data-cy="sporsmal-tittel"]')).toHaveText('Reise med bil')
 
-            await svarJaNeiStor(page, 'JA')
+            await svarJaHovedsporsmal(page)
             await expect(page.locator('.undersporsmal > :nth-child(1) > :nth-child(1)')).toHaveText(
                 'Hvilke dager reiste du med bil i perioden 23. desember 2020 - 7. januar 2021?',
             )
@@ -185,7 +185,7 @@ test.describe('Teste førsteside i reisetilskuddsøknaden', () => {
             await expect(page).toHaveURL(new RegExp(`${nyttReisetilskudd.id}/5`))
             await expect(page.locator('[data-cy="sporsmal-tittel"]')).toHaveText('Utbetaling')
 
-            await svarJaNeiStor(page, 'JA')
+            await svarJaHovedsporsmal(page)
             await validerAxeUtilityWrapper(page, test.info())
             await klikkGaVidere(page)
             steg.value++

--- a/playwright/tidssone-datovisning.spec.ts
+++ b/playwright/tidssone-datovisning.spec.ts
@@ -13,6 +13,7 @@ import {
     svarRadioGruppe,
     svarFritekst,
     svarJaHovedsporsmal,
+    svarJaNeiStor,
 } from './utils/utilities'
 
 /**
@@ -49,7 +50,7 @@ test.describe('Tidssone: periodevisning', () => {
 
             await checkViStolerPaDeg(page)
 
-            await page.locator('[data-cy="ja-nei-stor"] input[value="JA"]').check()
+            await svarJaNeiStor(page, 'JA')
             await expect(page.getByText('Når begynte du å jobbe igjen?')).toBeVisible()
 
             const datoInput = page.locator('.aksel-date__field-input')
@@ -255,7 +256,7 @@ test.describe('Tidssone: DATOER-kalender persistering', () => {
 test.describe('Tidssone: periode-komp fromDate-grense', () => {
     const åpnePeriodeKalender = async (page: import('@playwright/test').Page) => {
         await page.goto(`/syk/sykepengesoknad/soknader/${arbeidstaker.id}/3`)
-        await page.locator('[data-cy="ja-nei-stor"] input[value="JA"]').check()
+        await svarJaNeiStor(page, 'JA')
         const periodeLocator = page.locator('[data-cy="periode"]').first()
         await periodeLocator.locator('.aksel-date__field-button').first().click()
         await expect(page.getByRole('grid')).toBeVisible()
@@ -295,7 +296,7 @@ test.describe('Tidssone: periode-komp fromDate-grense', () => {
 test.describe('Tidssone: periode-komp datoer persistering', () => {
     const velgPeriodeOgNavigerTilbake = async (page: import('@playwright/test').Page) => {
         await page.goto(`/syk/sykepengesoknad/soknader/${arbeidstaker.id}/3`)
-        await page.locator('[data-cy="ja-nei-stor"] input[value="JA"]').check()
+        await svarJaNeiStor(page, 'JA')
         const periodeLocator = page.locator('[data-cy="periode"]').first()
         await periodeLocator.locator('.aksel-date__field-button').first().click()
         await periodeLocator.locator('[data-day="2020-04-05"]').click()

--- a/playwright/tidssone-datovisning.spec.ts
+++ b/playwright/tidssone-datovisning.spec.ts
@@ -13,7 +13,6 @@ import {
     svarRadioGruppe,
     svarFritekst,
     svarJaHovedsporsmal,
-    svarJaNeiStor,
 } from './utils/utilities'
 
 /**
@@ -50,7 +49,7 @@ test.describe('Tidssone: periodevisning', () => {
 
             await checkViStolerPaDeg(page)
 
-            await svarJaNeiStor(page, 'JA')
+            await svarJaHovedsporsmal(page)
             await expect(page.getByText('Når begynte du å jobbe igjen?')).toBeVisible()
 
             const datoInput = page.locator('.aksel-date__field-input')
@@ -256,7 +255,7 @@ test.describe('Tidssone: DATOER-kalender persistering', () => {
 test.describe('Tidssone: periode-komp fromDate-grense', () => {
     const åpnePeriodeKalender = async (page: import('@playwright/test').Page) => {
         await page.goto(`/syk/sykepengesoknad/soknader/${arbeidstaker.id}/3`)
-        await svarJaNeiStor(page, 'JA')
+        await svarJaHovedsporsmal(page)
         const periodeLocator = page.locator('[data-cy="periode"]').first()
         await periodeLocator.locator('.aksel-date__field-button').first().click()
         await expect(page.getByRole('grid')).toBeVisible()
@@ -296,7 +295,7 @@ test.describe('Tidssone: periode-komp fromDate-grense', () => {
 test.describe('Tidssone: periode-komp datoer persistering', () => {
     const velgPeriodeOgNavigerTilbake = async (page: import('@playwright/test').Page) => {
         await page.goto(`/syk/sykepengesoknad/soknader/${arbeidstaker.id}/3`)
-        await svarJaNeiStor(page, 'JA')
+        await svarJaHovedsporsmal(page)
         const periodeLocator = page.locator('[data-cy="periode"]').first()
         await periodeLocator.locator('.aksel-date__field-button').first().click()
         await periodeLocator.locator('[data-day="2020-04-05"]').click()

--- a/playwright/utils/utilities.ts
+++ b/playwright/utils/utilities.ts
@@ -19,7 +19,10 @@ export async function svarJaHovedsporsmal(page: Page) {
 }
 
 export async function svarJaNeiStor(page: Page, svar: 'JA' | 'NEI' = 'JA') {
-    await page.locator(`[data-cy="ja-nei-stor"] input[value="${svar}"]`).check()
+    const tekst = svar === 'JA' ? 'Ja' : 'Nei'
+    const radio = page.locator('form').getByRole('radio', { name: tekst }).first()
+    await radio.check()
+    await expect(radio).toBeChecked()
 }
 
 export async function svarNeiHovedsporsmal(page: Page) {

--- a/playwright/utils/utilities.ts
+++ b/playwright/utils/utilities.ts
@@ -18,6 +18,10 @@ export async function svarJaHovedsporsmal(page: Page) {
     await expect(radioButton).toBeChecked()
 }
 
+export async function svarJaNeiStor(page: Page, svar: 'JA' | 'NEI' = 'JA') {
+    await page.locator(`[data-cy="ja-nei-stor"] input[value="${svar}"]`).check()
+}
+
 export async function svarNeiHovedsporsmal(page: Page) {
     const radioButton = page.locator('form').getByRole('radio', { name: 'Nei' }).first()
     await radioButton.click()

--- a/playwright/utils/utilities.ts
+++ b/playwright/utils/utilities.ts
@@ -18,13 +18,6 @@ export async function svarJaHovedsporsmal(page: Page) {
     await expect(radioButton).toBeChecked()
 }
 
-export async function svarJaNeiStor(page: Page, svar: 'JA' | 'NEI' = 'JA') {
-    const tekst = svar === 'JA' ? 'Ja' : 'Nei'
-    const radio = page.locator('form').getByRole('radio', { name: tekst }).first()
-    await radio.check()
-    await expect(radio).toBeChecked()
-}
-
 export async function svarNeiHovedsporsmal(page: Page) {
     const radioButton = page.locator('form').getByRole('radio', { name: 'Nei' }).first()
     await radioButton.click()

--- a/src/components/sporsmal/typer/ja-nei-stor.tsx
+++ b/src/components/sporsmal/typer/ja-nei-stor.tsx
@@ -109,7 +109,6 @@ const JaNeiStor = ({ sporsmal }: SpmProps) => {
                             {...field}
                             legend={sporsmalstekst()}
                             description={sporsmal.undertekst}
-                            data-cy="ja-nei-stor"
                             className="w-full"
                             key={sporsmal.id}
                             error={fieldState.error && feilmelding.lokal}


### PR DESCRIPTION
Rydder opp i Playwright-testene ved å fjerne det overflødige `data-cy`-baserte mønsteret for å svare på store ja/nei-spørsmål.

- Fjerner `svarJaNeiStor` — dekkes fullt ut av de eksisterende `svarJaHovedsporsmal` og `svarNeiHovedsporsmal`
- Fjerner `data-cy="ja-nei-stor"` fra `RadioGroup` i `ja-nei-stor.tsx`
- Erstatter alle ~20 kall til `svarJaNeiStor(page, 'JA'/'NEI')` i 8 spec-filer med de eksisterende util-funksjonene
- Ingen endring i testadferd

Stacket oppå `oppgrader-til-aksel-8` for å holde selve Aksel-oppgraderingen mindre.