### PR TITLE
Bytt ConfirmationPanel med CheckboxGroup på bekreftelsesboksen

### DIFF
--- a/playwright/0_arbeidstaker_100.spec.ts
+++ b/playwright/0_arbeidstaker_100.spec.ts
@@ -50,7 +50,9 @@ test.describe('Tester arbeidstakersøknad - 100%', () => {
 
             await page.getByText('Start søknad').click()
             await expect(page.getByText('Det er 1 feil i skjemaet')).toBeVisible()
-            await expect(page.locator('[data-cy="bekreftCheckboksPanel"]')).toBeVisible()
+            await expect(
+                page.getByRole('checkbox', { name: 'Jeg bekrefter at jeg vil svare så riktig som jeg kan.' }),
+            ).toBeVisible()
             await expect(page.getByText('Du må bekrefte at du vil svare så riktig du kan')).toBeVisible()
 
             await validerAxeUtilityWrapper(page, test.info())

--- a/playwright/0_arbeidstaker_100.spec.ts
+++ b/playwright/0_arbeidstaker_100.spec.ts
@@ -50,7 +50,7 @@ test.describe('Tester arbeidstakersøknad - 100%', () => {
 
             await page.getByText('Start søknad').click()
             await expect(page.getByText('Det er 1 feil i skjemaet')).toBeVisible()
-            await expect(page.locator('.aksel-confirmation-panel__inner')).toBeVisible()
+            await expect(page.locator('[data-cy="bekreftCheckboksPanel"]')).toBeVisible()
             await expect(page.getByText('Du må bekrefte at du vil svare så riktig du kan')).toBeVisible()
 
             await validerAxeUtilityWrapper(page, test.info())

--- a/playwright/0_arbeidstaker_50.spec.ts
+++ b/playwright/0_arbeidstaker_50.spec.ts
@@ -48,7 +48,7 @@ test.describe('Tester arbeidstakersøknad - gradert 50%', () => {
 
             await expect(page).toHaveURL(new RegExp(`.*${soknadId}\/1`))
 
-            await page.getByLabel('Jeg bekrefter at jeg vil svare så riktig som jeg kan.').check()
+            await page.getByRole('checkbox', { name: 'Jeg bekrefter at jeg vil svare så riktig som jeg kan.' }).check()
 
             await expect(page.getByRole('button', { name: 'Start søknad' })).toBeVisible()
             await validerAxeUtilityWrapper(page, test.info())

--- a/playwright/0_arbeidstaker_50.spec.ts
+++ b/playwright/0_arbeidstaker_50.spec.ts
@@ -2,7 +2,7 @@ import { test, expect, Page } from '@playwright/test'
 
 import { arbeidstakerGradert } from '../src/data/mock/data/soknad/arbeidstaker-gradert'
 
-import { apneReadmore, svarJaHovedsporsmal } from './utils/utilities'
+import { apneReadmore, checkViStolerPaDeg, svarJaHovedsporsmal } from './utils/utilities'
 import { validerAxeUtilityWrapper } from './uuvalidering'
 const fillTextFieldByLabel = async (page: Page, labelText: string, value: string, fallbackSelector?: string) => {
     try {
@@ -48,7 +48,7 @@ test.describe('Tester arbeidstakersøknad - gradert 50%', () => {
 
             await expect(page).toHaveURL(new RegExp(`.*${soknadId}\/1`))
 
-            await page.getByRole('checkbox', { name: 'Jeg bekrefter at jeg vil svare så riktig som jeg kan.' }).check()
+            await checkViStolerPaDeg(page, false)
 
             await expect(page.getByRole('button', { name: 'Start søknad' })).toBeVisible()
             await validerAxeUtilityWrapper(page, test.info())

--- a/playwright/0_gammel_oppsumering.spec.ts
+++ b/playwright/0_gammel_oppsumering.spec.ts
@@ -49,7 +49,7 @@ test.describe('Sjekker at søknader med gammel oppsummering ser ok ut', () => {
 
             await page.getByText('Start søknad').click()
             await expect(page.getByText('Det er 1 feil i skjemaet')).toBeVisible()
-            await expect(page.locator('.aksel-confirmation-panel__inner')).toBeVisible()
+            await expect(page.locator('[data-cy="bekreftCheckboksPanel"]')).toBeVisible()
             await expect(page.getByText('Du må bekrefte at du vil svare så riktig du kan')).toBeVisible()
             await page.locator('.aksel-checkbox__label').click()
 

--- a/playwright/0_gammel_oppsumering.spec.ts
+++ b/playwright/0_gammel_oppsumering.spec.ts
@@ -49,9 +49,11 @@ test.describe('Sjekker at søknader med gammel oppsummering ser ok ut', () => {
 
             await page.getByText('Start søknad').click()
             await expect(page.getByText('Det er 1 feil i skjemaet')).toBeVisible()
-            await expect(page.locator('[data-cy="bekreftCheckboksPanel"]')).toBeVisible()
+            await expect(
+                page.getByRole('checkbox', { name: 'Jeg bekrefter at jeg vil svare så riktig som jeg kan.' }),
+            ).toBeVisible()
             await expect(page.getByText('Du må bekrefte at du vil svare så riktig du kan')).toBeVisible()
-            await page.locator('.aksel-checkbox__label').click()
+            await page.getByRole('checkbox', { name: 'Jeg bekrefter at jeg vil svare så riktig som jeg kan.' }).check()
 
             await validerAxeUtilityWrapper(page, test.info())
             await page.getByText('Start søknad').click()

--- a/playwright/3_cummulative_layout_shift.spec.ts
+++ b/playwright/3_cummulative_layout_shift.spec.ts
@@ -52,7 +52,9 @@ test.describe('Tester cummulative-layout-shift', () => {
             '/syk/sykepengesoknad/soknader/04247ad5-9c15-4b7d-ae55-f23807777777/1?testperson=cummulative-layout-shift',
         )
         // await mainSkalHaHoyde(page, 1657)
-        await expect(page.getByText('Jeg bekrefter at jeg vil svare så riktig som jeg kan.')).toBeVisible({
+        await expect(
+            page.getByRole('checkbox', { name: 'Jeg bekrefter at jeg vil svare så riktig som jeg kan.' }),
+        ).toBeVisible({
             timeout: 10000,
         })
 

--- a/playwright/3_soknad_med_eldre_soknader.spec.ts
+++ b/playwright/3_soknad_med_eldre_soknader.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test'
 
-import { svarNeiHovedsporsmal, klikkGaVidere } from './utils/utilities'
+import { svarNeiHovedsporsmal, klikkGaVidere, checkViStolerPaDeg } from './utils/utilities'
 import { validerAxeUtilityWrapper } from './uuvalidering'
 
 test.describe('Eldre søknader', () => {
@@ -78,8 +78,7 @@ test.describe('Eldre søknader', () => {
 
 // Felles hjelpefunksjon – async!
 async function fyllUtSoknad(page) {
-    await page.getByRole('checkbox', { name: 'Jeg bekrefter at jeg vil svare så riktig som jeg kan.' }).check()
-    await page.getByText('Start søknad').click()
+    await checkViStolerPaDeg(page)
     await svarNeiHovedsporsmal(page)
     await klikkGaVidere(page)
     await page.getByText('Send søknaden').click()

--- a/playwright/3_soknad_med_eldre_soknader.spec.ts
+++ b/playwright/3_soknad_med_eldre_soknader.spec.ts
@@ -78,7 +78,7 @@ test.describe('Eldre søknader', () => {
 
 // Felles hjelpefunksjon – async!
 async function fyllUtSoknad(page) {
-    await page.getByText('Jeg bekrefter at jeg vil svare så riktig som jeg kan.').click()
+    await page.getByRole('checkbox', { name: 'Jeg bekrefter at jeg vil svare så riktig som jeg kan.' }).check()
     await page.getByText('Start søknad').click()
     await svarNeiHovedsporsmal(page)
     await klikkGaVidere(page)

--- a/playwright/feilsituasjon-handtering.spec.ts
+++ b/playwright/feilsituasjon-handtering.spec.ts
@@ -85,7 +85,9 @@ test.describe('Tester feilsituasjoner', () => {
             await page.goto(`/syk/sykepengesoknad/soknader/${soknad.id}/1${testpersonQuery}`)
             await expect(page.getByRole('heading', { name: SOKNAD_OM_SYKEPENGER })).toBeVisible()
 
-            const checkbox = page.locator('[data-cy="bekreftCheckboksPanel"]')
+            const checkbox = page.getByRole('checkbox', {
+                name: 'Jeg bekrefter at jeg vil svare så riktig som jeg kan.',
+            })
             await expect(checkbox).not.toBeChecked()
 
             await checkViStolerPaDeg(page)

--- a/src/components/sporsmal/typer/checkbox-panel.tsx
+++ b/src/components/sporsmal/typer/checkbox-panel.tsx
@@ -52,7 +52,9 @@ const CheckboxInput = ({ sporsmal }: SpmProps) => {
                             })
                         }}
                     >
-                        <Checkbox value={spm.id}>{spm.sporsmalstekst}</Checkbox>
+                        <Checkbox id={spm.id} value={spm.id}>
+                            {spm.sporsmalstekst}
+                        </Checkbox>
                     </CheckboxGroup>
                 </Box>
             )}

--- a/src/components/sporsmal/typer/checkbox-panel.tsx
+++ b/src/components/sporsmal/typer/checkbox-panel.tsx
@@ -29,7 +29,12 @@ const CheckboxInput = ({ sporsmal }: SpmProps) => {
                     borderRadius="8"
                     borderWidth="1"
                     padding="space-16"
-                    className="transition-colors duration-100 [&_.aksel-checkbox:focus-within::after]:hidden"
+                    className="cursor-pointer transition-colors duration-100 [&_.aksel-checkbox:focus-within::after]:hidden"
+                    onClick={(e) => {
+                        if (!(e.target as HTMLElement).closest('.aksel-checkbox')) {
+                            field.onChange(!field.value)
+                        }
+                    }}
                 >
                     <CheckboxGroup
                         legend={spm.sporsmalstekst}

--- a/src/components/sporsmal/typer/checkbox-panel.tsx
+++ b/src/components/sporsmal/typer/checkbox-panel.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, CheckboxGroup } from '@navikt/ds-react'
+import { Box, Checkbox, CheckboxGroup } from '@navikt/ds-react'
 import React from 'react'
 import { Controller } from 'react-hook-form'
 
@@ -7,7 +7,6 @@ import { hentFeilmelding } from '../sporsmal-utils'
 import { useCheckboxNavigasjon } from '../../../utils/tastatur-navigasjon'
 import { logEvent } from '../../umami/umami'
 import { useSoknadMedDetaljer } from '../../../hooks/useSoknadMedDetaljer'
-import { cn } from '../../../utils/tw-utils'
 
 const CheckboxInput = ({ sporsmal }: SpmProps) => {
     const spm = sporsmal.tag === 'BEKREFT_OPPLYSNINGER_UTLAND_INFO' ? sporsmal.undersporsmal[0] : sporsmal
@@ -22,16 +21,15 @@ const CheckboxInput = ({ sporsmal }: SpmProps) => {
             name={spm.id}
             rules={{ required: feilmelding.global }}
             render={({ field, fieldState }) => (
-                <div
-                    className={cn(
-                        'rounded-(--ax-radius-8) border p-4 transition-colors duration-100',
-                        '[&_.aksel-checkbox:focus-within::after]:hidden',
-                        fieldState.error
-                            ? 'border-ax-border-danger bg-ax-bg-danger-moderate'
-                            : field.value
-                              ? 'border-ax-border-success bg-ax-bg-success-moderate'
-                              : 'border-ax-border-warning bg-ax-bg-warning-moderate',
-                    )}
+                <Box
+                    background={
+                        fieldState.error ? 'danger-moderate' : field.value ? 'success-moderate' : 'warning-moderate'
+                    }
+                    borderColor={fieldState.error ? 'danger' : field.value ? 'success' : 'warning'}
+                    borderRadius="8"
+                    borderWidth="1"
+                    padding="space-16"
+                    className="transition-colors duration-100 [&_.aksel-checkbox:focus-within::after]:hidden"
                 >
                     <CheckboxGroup
                         legend={spm.sporsmalstekst}
@@ -51,7 +49,7 @@ const CheckboxInput = ({ sporsmal }: SpmProps) => {
                     >
                         <Checkbox value={spm.id}>{spm.sporsmalstekst}</Checkbox>
                     </CheckboxGroup>
-                </div>
+                </Box>
             )}
         />
     )

--- a/src/components/sporsmal/typer/checkbox-panel.tsx
+++ b/src/components/sporsmal/typer/checkbox-panel.tsx
@@ -49,9 +49,7 @@ const CheckboxInput = ({ sporsmal }: SpmProps) => {
                             })
                         }}
                     >
-                        <Checkbox value={spm.id} data-cy="bekreftCheckboksPanel">
-                            {spm.sporsmalstekst}
-                        </Checkbox>
+                        <Checkbox value={spm.id}>{spm.sporsmalstekst}</Checkbox>
                     </CheckboxGroup>
                 </div>
             )}

--- a/src/components/sporsmal/typer/checkbox-panel.tsx
+++ b/src/components/sporsmal/typer/checkbox-panel.tsx
@@ -38,6 +38,7 @@ const CheckboxInput = ({ sporsmal }: SpmProps) => {
                     label={spm.sporsmalstekst}
                     error={fieldState.error && feilmelding.lokal}
                     data-cy="bekreftCheckboksPanel"
+                    className="block w-full [&_.aksel-checkbox:focus-within::after]:hidden cursor-pointer"
                 />
             )}
         />

--- a/src/components/sporsmal/typer/checkbox-panel.tsx
+++ b/src/components/sporsmal/typer/checkbox-panel.tsx
@@ -1,4 +1,4 @@
-import { ConfirmationPanel } from '@navikt/ds-react'
+import { Checkbox, CheckboxGroup } from '@navikt/ds-react'
 import React from 'react'
 import { Controller } from 'react-hook-form'
 
@@ -7,6 +7,7 @@ import { hentFeilmelding } from '../sporsmal-utils'
 import { useCheckboxNavigasjon } from '../../../utils/tastatur-navigasjon'
 import { logEvent } from '../../umami/umami'
 import { useSoknadMedDetaljer } from '../../../hooks/useSoknadMedDetaljer'
+import { cn } from '../../../utils/tw-utils'
 
 const CheckboxInput = ({ sporsmal }: SpmProps) => {
     const spm = sporsmal.tag === 'BEKREFT_OPPLYSNINGER_UTLAND_INFO' ? sporsmal.undersporsmal[0] : sporsmal
@@ -19,27 +20,40 @@ const CheckboxInput = ({ sporsmal }: SpmProps) => {
         <Controller
             defaultValue={false}
             name={spm.id}
-            rules={{
-                required: feilmelding.global,
-                onChange: (event) => {
-                    logEvent('skjema spørsmål besvart', {
-                        soknadstype: valgtSoknad?.soknadstype,
-                        skjemanavn: 'sykepengesoknad',
-                        spørsmål: sporsmal.tag,
-                        svar: event.target.value ? 'CHECKED' : 'UNCHECKED',
-                    })
-                },
-            }}
+            rules={{ required: feilmelding.global }}
             render={({ field, fieldState }) => (
-                <ConfirmationPanel
-                    {...field}
-                    checked={field.value}
-                    id={field.name}
-                    label={spm.sporsmalstekst}
-                    error={fieldState.error && feilmelding.lokal}
-                    data-cy="bekreftCheckboksPanel"
-                    className="block w-full [&_.aksel-checkbox:focus-within::after]:hidden cursor-pointer"
-                />
+                <div
+                    className={cn(
+                        'rounded-(--ax-radius-8) border p-4 transition-colors duration-100',
+                        '[&_.aksel-checkbox:focus-within::after]:hidden',
+                        fieldState.error
+                            ? 'border-ax-border-danger bg-ax-bg-danger-moderate'
+                            : field.value
+                              ? 'border-ax-border-success bg-ax-bg-success-moderate'
+                              : 'border-ax-border-warning bg-ax-bg-warning-moderate',
+                    )}
+                >
+                    <CheckboxGroup
+                        legend={spm.sporsmalstekst}
+                        hideLegend
+                        error={fieldState.error && feilmelding.lokal}
+                        value={field.value ? [spm.id] : []}
+                        onChange={(vals) => {
+                            const erBekreftet = vals.includes(spm.id)
+                            field.onChange(erBekreftet)
+                            logEvent('skjema spørsmål besvart', {
+                                soknadstype: valgtSoknad?.soknadstype,
+                                skjemanavn: 'sykepengesoknad',
+                                spørsmål: sporsmal.tag,
+                                svar: erBekreftet ? 'CHECKED' : 'UNCHECKED',
+                            })
+                        }}
+                    >
+                        <Checkbox value={spm.id} data-cy="bekreftCheckboksPanel">
+                            {spm.sporsmalstekst}
+                        </Checkbox>
+                    </CheckboxGroup>
+                </div>
             )}
         />
     )


### PR DESCRIPTION
Går vekk fra deprecated `ConfirmationPanel` (fjernet i Aksel v8) og bygger bekreftelsesboksen på introsiden med `CheckboxGroup`/`Checkbox` i stedet.

- Bruker Aksel `Box` for wrapper (semantiske tokens: `borderColor`, `background`, `borderRadius`, `borderWidth`) i stedet for Tailwind `div`
- Fjerner border ved klikk på checkbox
- Fjerner `data-cy="bekreftCheckboksPanel"` — tester bruker nå `getByRole('checkbox', { name: ... })`
- Erstatter `getByLabel`/`getByText`-selektorer som matchet to elementer etter `CheckboxGroup`-innføring (strict mode violation)
- Erstatter inline checkbox-kall med `checkViStolerPaDeg` fra utils der mulig
- Oppdaterer Playwright-tester som pekte på `.aksel-confirmation-panel__inner`

Stacket oppå `oppgrader-til-aksel-8`.