### PR TITLE
Skip flaky test som ikke engang tester det den skal teste

### DIFF
--- a/playwright/3_cummulative_layout_shift.spec.ts
+++ b/playwright/3_cummulative_layout_shift.spec.ts
@@ -2,7 +2,7 @@ import { test, expect, Page } from '@playwright/test'
 
 import { harSynligTittel, harSynligTekst } from './utils/utilities'
 
-test.describe('Tester cummulative-layout-shift', () => {
+test.describe.skip('Tester cummulative-layout-shift', () => {
     async function ventTilIngenSkeletons(page: Page) {
         await expect(page.locator('.aksel-skeleton')).toHaveCount(0, { timeout: 10000 })
     }


### PR DESCRIPTION
Denne testen har vært dau siden cypress til playwright migreringen, med utkommentert kode. Kan la den ligge som en påminner om å faktisk lage en CLS test som fungerer, men inntil videre så er den bare flaky og ødelegger.